### PR TITLE
XDC and FASM Yosys plugins for INTERNAL_VREF support.

### DIFF
--- a/bank_tiles.h
+++ b/bank_tiles.h
@@ -25,7 +25,6 @@ USING_YOSYS_NAMESPACE
 // Coordinates of HCLK_IOI tiles associated with a specified bank
 using BankTilesMap = std::unordered_map<int, std::string>;
 BankTilesMap bank_tiles;
-using json11::Json;
 
 // Find the part's JSON file with information including the IO Banks
 // and extract the bank tiles.
@@ -38,7 +37,7 @@ BankTilesMap get_bank_tiles(const std::string json_file_name) {
 	std::string json_str((std::istreambuf_iterator<char>(json_file)),
 			std::istreambuf_iterator<char>());
 	std::string error;
-	Json json = Json::parse(json_str, error);
+	auto json = json11::Json::parse(json_str, error);
 	if (!error.empty()) {
 		log_cmd_error("%s\n", error.c_str());
 	}

--- a/bank_tiles.h
+++ b/bank_tiles.h
@@ -24,7 +24,6 @@
 USING_YOSYS_NAMESPACE
 // Coordinates of HCLK_IOI tiles associated with a specified bank
 using BankTilesMap = std::unordered_map<int, std::string>;
-BankTilesMap bank_tiles;
 
 // Find the part's JSON file with information including the IO Banks
 // and extract the bank tiles.
@@ -53,3 +52,4 @@ BankTilesMap get_bank_tiles(const std::string json_file_name) {
 
 	return bank_tiles;
 }
+

--- a/bank_tiles.h
+++ b/bank_tiles.h
@@ -1,0 +1,63 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *  Copyright (C) 2019  The Symbiflow Authors
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+#include "kernel/log.h"
+#include "libs/json11/json11.hpp"
+//#include <sstream>
+
+#define PART_JSON "PRJXRAY_PART_JSON"
+
+USING_YOSYS_NAMESPACE
+// Coordinates of HCLK_IOI tiles associated with a specified bank
+using BankTilesMap = std::unordered_map<int, std::string>;
+using json11::Json;
+
+// Find the part's JSON file with information including the IO Banks
+// and extract the bank tiles.
+BankTilesMap get_bank_tiles() {
+	BankTilesMap bank_tiles;
+	std::string part_json;
+	try {
+		part_json = std::string(getenv(PART_JSON));
+	} catch (...) {
+		log("write_fasm: %s not defined\n", PART_JSON);
+		return BankTilesMap();
+	}
+	std::ifstream json_file(part_json);
+	std::string json_str((std::istreambuf_iterator<char>(json_file)),
+                 std::istreambuf_iterator<char>());
+	std::string error;
+	Json json = Json::parse(json_str, error);
+	if (!error.empty()) {
+		log("get_bank_tiles: json parsing failed \n");
+		return BankTilesMap();
+	}
+	auto json_objects = json.object_items();
+	auto iobanks = json_objects.find("iobanks");
+	if (iobanks == json_objects.end()) {
+		log("get_bank_tiles: IO Banks information missing in the part's json: %s\n", part_json.c_str());
+		return BankTilesMap();
+	}
+
+	for (auto iobank : iobanks->second.object_items()) {
+		bank_tiles.emplace(std::atoi(iobank.first.c_str()), iobank.second.string_value());
+	}
+
+	return bank_tiles;
+}

--- a/fasm-plugin/Makefile
+++ b/fasm-plugin/Makefile
@@ -1,0 +1,19 @@
+CXX = $(shell yosys-config --cxx)
+CXXFLAGS = $(shell yosys-config --cxxflags)
+LDFLAGS = $(shell yosys-config --ldflags)
+LDLIBS = $(shell yosys-config --ldlibs)
+PLUGINS_DIR = $(shell yosys-config --datdir)/plugins
+
+OBJS = fasm.o
+
+fasm.so: $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
+
+.PHONY: install
+install: fasm.so
+	mkdir -p $(PLUGINS_DIR)
+	cp $< $(PLUGINS_DIR)/$<
+
+clean:
+	rm -f *.d *.o fasm.so
+

--- a/fasm-plugin/fasm.cc
+++ b/fasm-plugin/fasm.cc
@@ -47,35 +47,38 @@ struct WriteFasm : public Backend {
 
 	void execute(std::ostream *&f, std::string filename,  std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		size_t argidx = 1;
+		std::string part_json;
+		if (args[argidx] == "-part_json" && argidx + 1 < args.size()) {
+			part_json = args[++argidx];
+			argidx++;
+		}
 		extra_args(f, filename, args, argidx);
-		process_vref(f, design);
+		process_vref(f, design, part_json);
 	}
 
-	void process_vref(std::ostream *&f, RTLIL::Design* design) {
+	void process_vref(std::ostream *&f, RTLIL::Design* design, const std::string& part_json) {
 		RTLIL::Module* top_module(design->top_module());
 		if (top_module == nullptr) {
-			log("write_fasm: No top module detected.\n");
-			return;
+			log_cmd_error("%s: No top module detected.\n", pass_name.c_str());
 		}
 		// Return if no BANK module exists as this means there are no cells
 		if (!design->has(ID(BANK))) {
+			log_warning("%s: No extra fasm features found in the design.\n", pass_name.c_str());
 			return;
 		}
 
-		BankTilesMap bank_tiles(get_bank_tiles());
+		bank_tiles = get_bank_tiles(part_json);
 		// Generate a fasm feature associated with the INTERNAL_VREF value per bank
 		// e.g. VREF value of 0.675 for bank 34 is associated with tile HCLK_IOI3_X113Y26
 		// hence we need to emit the following fasm feature: HCLK_IOI3_X113Y26.VREF.V_675_MV
 		for (auto cell : top_module->cells()) {
 			if (cell->type != ID(BANK)) continue;
 			if (bank_tiles.size() == 0) {
-				log("write_fasm: No bank tiles available on the target part.\n");
-				return;
+				log_cmd_error("%s: No bank tiles available on the target part.\n", pass_name.c_str());
 			}
 			int bank_number(cell->getParam(ID(NUMBER)).as_int());
 			if (bank_tiles.count(bank_number) == 0) {
-				log("write_fasm: No IO bank number %d on the target part.\n", bank_number);
-				return;
+				log_cmd_error("%s: No IO bank number %d on the target part.\n", pass_name.c_str(), bank_number);
 			}
 			int bank_vref(cell->getParam(ID(INTERNAL_VREF)).as_int());
 			*f << "HCLK_IOI3_" << bank_tiles[bank_number] <<".VREF.V_" << bank_vref << "_MV\n";

--- a/fasm-plugin/fasm.cc
+++ b/fasm-plugin/fasm.cc
@@ -61,7 +61,7 @@ struct WriteFasm : public Backend {
 		if (top_module == nullptr) {
 			log_cmd_error("%s: No top module detected.\n", pass_name.c_str());
 		}
-		bank_tiles = get_bank_tiles(part_json);
+		auto bank_tiles = get_bank_tiles(part_json);
 		// Generate a fasm feature associated with the INTERNAL_VREF value per bank
 		// e.g. VREF value of 0.675 for bank 34 is associated with tile HCLK_IOI3_X113Y26
 		// hence we need to emit the following fasm feature: HCLK_IOI3_X113Y26.VREF.V_675_MV

--- a/fasm-plugin/fasm.cc
+++ b/fasm-plugin/fasm.cc
@@ -39,9 +39,9 @@ struct WriteFasm : public Backend {
 	void help() YS_OVERRIDE {
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    write_fasm filename\n");
+		log("    write_fasm -part_json <part_json_filename> <filename>\n");
 		log("\n");
-		log("Write out a file with vref FASM features\n");
+		log("Write out a file with vref FASM features.\n");
 		log("\n");
 	}
 

--- a/fasm-plugin/fasm.cc
+++ b/fasm-plugin/fasm.cc
@@ -1,0 +1,87 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *  Copyright (C) 2019  The Symbiflow Authors
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *  ---
+ *
+ *   XDC commands + FASM backend.
+ *
+ *   This plugin operates on the existing design and modifies its structure
+ *   based on the content of the XDC (Xilinx Design Constraints) file.
+ *   Since the XDC file consists of Tcl commands it is read using Yosys's
+ *   tcl command and processed by the new XDC commands imported to the
+ *   Tcl interpreter.
+ */
+
+#include "kernel/register.h"
+#include "kernel/rtlil.h"
+#include "kernel/log.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+// Coordinates of HCLK_IOI tiles associated with a specified bank
+// This is very part specific and is for Arty's xc7a35tcsg324 part
+std::unordered_map<int, std::string> bank_tiles = {
+	{14, "X1Y26"},
+	{15, "X1Y78"},
+	{16, "X1Y130"},
+	{34, "X113Y26"},
+	{35, "X113Y78"}
+};
+
+struct WriteFasm : public Backend {
+	WriteFasm() : Backend("fasm", "Write out FASM features") { }
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    write_fasm filename\n");
+		log("\n");
+		log("Write out a file with vref FASM features\n");
+		log("\n");
+	}
+	void execute(std::ostream *&f, std::string filename,  std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		size_t argidx = 1;
+		extra_args(f, filename, args, argidx);
+		process_vref(f, design);
+	}
+
+	void process_vref(std::ostream *&f, RTLIL::Design* design) {
+		RTLIL::Module* top_module(design->top_module());
+		if (top_module == nullptr) {
+			log("No top module detected\n");
+			return;
+		}
+		// Return if no BANK module exists as this means there are no cells
+		if (!design->has(ID(BANK))) {
+			return;
+		}
+		// Generate a fasm feature associated with the INTERNAL_VREF value per bank
+		// e.g. VREF value of 0.675 for bank 34 is associated with tile HCLK_IOI3_X113Y26
+		// hence we need to emit the following fasm feature: HCLK_IOI3_X113Y26.VREF.V_675_MV
+		for (auto cell : top_module->cells()) {
+                        if (cell->type != ID(BANK)) continue;
+			int bank_number(cell->getParam(ID(NUMBER)).as_int());
+			int bank_vref(cell->getParam(ID(INTERNAL_VREF)).as_int());
+			*f << "HCLK_IOI3_" << bank_tiles[bank_number] <<".VREF.V_" << bank_vref << "_MV\n";
+                }
+	}
+} WriteFasm;
+
+PRIVATE_NAMESPACE_END

--- a/fasm-plugin/fasm.cc
+++ b/fasm-plugin/fasm.cc
@@ -30,24 +30,16 @@
 #include "kernel/register.h"
 #include "kernel/rtlil.h"
 #include "kernel/log.h"
+#include "../bank_tiles.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-// Coordinates of HCLK_IOI tiles associated with a specified bank
-// This is very part specific and is for Arty's xc7a35tcsg324 part
-std::unordered_map<int, std::string> bank_tiles = {
-	{14, "X1Y26"},
-	{15, "X1Y78"},
-	{16, "X1Y130"},
-	{34, "X113Y26"},
-	{35, "X113Y78"}
-};
-
 struct WriteFasm : public Backend {
-	WriteFasm() : Backend("fasm", "Write out FASM features") { }
-	void help() YS_OVERRIDE
-	{
+	WriteFasm() : Backend("fasm", "Write out FASM features") {}
+
+
+	void help() YS_OVERRIDE {
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
 		log("    write_fasm filename\n");
@@ -55,8 +47,8 @@ struct WriteFasm : public Backend {
 		log("Write out a file with vref FASM features\n");
 		log("\n");
 	}
-	void execute(std::ostream *&f, std::string filename,  std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
-	{
+
+	void execute(std::ostream *&f, std::string filename,  std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		size_t argidx = 1;
 		extra_args(f, filename, args, argidx);
 		process_vref(f, design);
@@ -65,22 +57,26 @@ struct WriteFasm : public Backend {
 	void process_vref(std::ostream *&f, RTLIL::Design* design) {
 		RTLIL::Module* top_module(design->top_module());
 		if (top_module == nullptr) {
-			log("No top module detected\n");
+			log("write_fasm: No top module detected\n");
 			return;
 		}
 		// Return if no BANK module exists as this means there are no cells
 		if (!design->has(ID(BANK))) {
 			return;
 		}
-		// Generate a fasm feature associated with the INTERNAL_VREF value per bank
-		// e.g. VREF value of 0.675 for bank 34 is associated with tile HCLK_IOI3_X113Y26
-		// hence we need to emit the following fasm feature: HCLK_IOI3_X113Y26.VREF.V_675_MV
-		for (auto cell : top_module->cells()) {
-                        if (cell->type != ID(BANK)) continue;
-			int bank_number(cell->getParam(ID(NUMBER)).as_int());
-			int bank_vref(cell->getParam(ID(INTERNAL_VREF)).as_int());
-			*f << "HCLK_IOI3_" << bank_tiles[bank_number] <<".VREF.V_" << bank_vref << "_MV\n";
-                }
+
+		BankTilesMap bank_tiles(get_bank_tiles());
+		if (bank_tiles.size()) {
+			// Generate a fasm feature associated with the INTERNAL_VREF value per bank
+			// e.g. VREF value of 0.675 for bank 34 is associated with tile HCLK_IOI3_X113Y26
+			// hence we need to emit the following fasm feature: HCLK_IOI3_X113Y26.VREF.V_675_MV
+			for (auto cell : top_module->cells()) {
+				if (cell->type != ID(BANK)) continue;
+				int bank_number(cell->getParam(ID(NUMBER)).as_int());
+				int bank_vref(cell->getParam(ID(INTERNAL_VREF)).as_int());
+				*f << "HCLK_IOI3_" << bank_tiles[bank_number] <<".VREF.V_" << bank_vref << "_MV\n";
+			}
+		}
 	}
 } WriteFasm;
 

--- a/fasm-plugin/fasm.cc
+++ b/fasm-plugin/fasm.cc
@@ -53,35 +53,31 @@ struct WriteFasm : public Backend {
 			argidx++;
 		}
 		extra_args(f, filename, args, argidx);
-		process_vref(f, design, part_json);
+		extract_fasm_features(f, design, part_json);
 	}
 
-	void process_vref(std::ostream *&f, RTLIL::Design* design, const std::string& part_json) {
+	void extract_fasm_features(std::ostream *&f, RTLIL::Design* design, const std::string& part_json) {
 		RTLIL::Module* top_module(design->top_module());
 		if (top_module == nullptr) {
 			log_cmd_error("%s: No top module detected.\n", pass_name.c_str());
 		}
-		// Return if no BANK module exists as this means there are no cells
-		if (!design->has(ID(BANK))) {
-			log_warning("%s: No extra fasm features found in the design.\n", pass_name.c_str());
-			return;
-		}
-
 		bank_tiles = get_bank_tiles(part_json);
 		// Generate a fasm feature associated with the INTERNAL_VREF value per bank
 		// e.g. VREF value of 0.675 for bank 34 is associated with tile HCLK_IOI3_X113Y26
 		// hence we need to emit the following fasm feature: HCLK_IOI3_X113Y26.VREF.V_675_MV
 		for (auto cell : top_module->cells()) {
-			if (cell->type != ID(BANK)) continue;
-			if (bank_tiles.size() == 0) {
-				log_cmd_error("%s: No bank tiles available on the target part.\n", pass_name.c_str());
+			if (!cell->hasParam(ID(FASM_EXTRA))) continue;
+			if (cell->getParam(ID(FASM_EXTRA)) == RTLIL::Const("INTERNAL_VREF")) {
+				if (bank_tiles.size() == 0) {
+					log_cmd_error("%s: No bank tiles available on the target part.\n", pass_name.c_str());
+				}
+				int bank_number(cell->getParam(ID(NUMBER)).as_int());
+				if (bank_tiles.count(bank_number) == 0) {
+					log_cmd_error("%s: No IO bank number %d on the target part.\n", pass_name.c_str(), bank_number);
+				}
+				int bank_vref(cell->getParam(ID(INTERNAL_VREF)).as_int());
+				*f << "HCLK_IOI3_" << bank_tiles[bank_number] <<".VREF.V_" << bank_vref << "_MV\n";
 			}
-			int bank_number(cell->getParam(ID(NUMBER)).as_int());
-			if (bank_tiles.count(bank_number) == 0) {
-				log_cmd_error("%s: No IO bank number %d on the target part.\n", pass_name.c_str(), bank_number);
-			}
-			int bank_vref(cell->getParam(ID(INTERNAL_VREF)).as_int());
-			*f << "HCLK_IOI3_" << bank_tiles[bank_number] <<".VREF.V_" << bank_vref << "_MV\n";
 		}
 	}
 } WriteFasm;

--- a/xdc-plugin/BANK.v
+++ b/xdc-plugin/BANK.v
@@ -1,0 +1,5 @@
+module BANK();
+	parameter FASM_EXTRA = "INTERNAL_VREF";
+	parameter NUMBER = 0;
+	parameter INTERNAL_VREF = 600;
+endmodule

--- a/xdc-plugin/Makefile
+++ b/xdc-plugin/Makefile
@@ -1,0 +1,19 @@
+CXX = $(shell yosys-config --cxx)
+CXXFLAGS = $(shell yosys-config --cxxflags)
+LDFLAGS = $(shell yosys-config --ldflags)
+LDLIBS = $(shell yosys-config --ldlibs)
+PLUGINS_DIR = $(shell yosys-config --datdir)/plugins
+
+OBJS = xdc.o
+
+xdc.so: $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
+
+.PHONY: install
+install: xdc.so
+	mkdir -p $(PLUGINS_DIR)
+	cp $< $(PLUGINS_DIR)/$<
+
+clean:
+	rm -f *.d *.o xdc.so
+

--- a/xdc-plugin/Makefile
+++ b/xdc-plugin/Makefile
@@ -5,14 +5,21 @@ LDLIBS = $(shell yosys-config --ldlibs)
 PLUGINS_DIR = $(shell yosys-config --datdir)/plugins
 
 OBJS = xdc.o
+VERILOG_MODULES = BANK.v
 
 xdc.so: $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
 
-.PHONY: install
-install: xdc.so
+install_plugin: xdc.so
 	mkdir -p $(PLUGINS_DIR)
 	cp $< $(PLUGINS_DIR)/$<
+
+install_modules: $(VERILOG_MODULES)
+	mkdir -p $(PLUGINS_DIR)/fasm_extra_modules/
+	cp $< $(PLUGINS_DIR)/fasm_extra_modules/$<
+
+.PHONY: install
+install: install_modules install_plugin
 
 clean:
 	rm -f *.d *.o xdc.so

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -55,7 +55,7 @@ struct ReadXdc : public Frontend {
 	void help() YS_OVERRIDE {
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    read_xdc <filename>\n");
+		log("    read_xdc -part_json <part_json_filename> <filename>\n");
 		log("\n");
 		log("Read XDC file.\n");
 		log("\n");

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -190,6 +190,7 @@ struct SetProperty : public Pass {
 		if (!design->has(ID(BANK))) {
 			RTLIL::Module* bank_module = design->addModule(ID(BANK));
 			bank_module->makeblackbox();
+			bank_module->avail_parameters.insert(ID(FASM_EXTRA));
 			bank_module->avail_parameters.insert(ID(NUMBER));
 			bank_module->avail_parameters.insert(ID(INTERNAL_VREF));
 		}
@@ -201,6 +202,7 @@ struct SetProperty : public Pass {
 		if (!bank_cell) {
 			bank_cell = top_module->addCell(RTLIL::IdString(bank_cell_name), ID(BANK));
 		}
+		bank_cell->setParam(ID(FASM_EXTRA), RTLIL::Const("INTERNAL_VREF"));
 		bank_cell->setParam(ID(NUMBER), RTLIL::Const(iobank));
 		bank_cell->setParam(ID(INTERNAL_VREF), RTLIL::Const(internal_vref));
 	}

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -37,10 +37,11 @@ USING_YOSYS_NAMESPACE
 
 PRIVATE_NAMESPACE_BEGIN
 
-enum SetPropertyOptions { INTERNAL_VREF };
 
-std::unordered_map<std::string, SetPropertyOptions> set_property_options_map  = {
-	{"INTERNAL_VREF", INTERNAL_VREF}
+enum class SetPropertyOptions { INTERNAL_VREF };
+
+const std::unordered_map<std::string, SetPropertyOptions> set_property_options_map  = {
+	{"INTERNAL_VREF", SetPropertyOptions::INTERNAL_VREF}
 };
 
 void register_in_tcl_interpreter(const std::string& command) {
@@ -158,8 +159,8 @@ struct SetProperty : public Pass {
 			return;
 		}
 
-		switch (set_property_options_map[option]) {
-			case INTERNAL_VREF:
+		switch (set_property_options_map.at(option)) {
+			case SetPropertyOptions::INTERNAL_VREF:
 				process_vref(std::vector<std::string>(args.begin() + 2, args.end()), design);
 				break;
 			default:

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -26,7 +26,7 @@
  *   Tcl interpreter and processed by the new XDC commands imported to the
  *   Tcl interpreter.
  */
-
+#include <cassert>
 #include "kernel/register.h"
 #include "kernel/rtlil.h"
 #include "kernel/log.h"

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -210,6 +210,7 @@ struct ReadXdc : public Frontend {
 		}
                 Tcl_Interp *interp = yosys_get_tcl_interp();
 		size_t argidx = 1;
+		bank_tiles.clear();
 		if (args[argidx] == "-part_json" && argidx + 1 < args.size()) {
 			bank_tiles = ::get_bank_tiles(args[++argidx]);
 			argidx++;

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -1,0 +1,173 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *  Copyright (C) 2019  The Symbiflow Authors
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *  ---
+ *
+ *   XDC commands + FASM backend.
+ *
+ *   This plugin operates on the existing design and modifies its structure
+ *   based on the content of the XDC (Xilinx Design Constraints) file.
+ *   Since the XDC file consists of Tcl commands it is read using Yosys's
+ *   tcl command and processed by the new XDC commands imported to the
+ *   Tcl interpreter.
+ */
+
+#include "kernel/register.h"
+#include "kernel/rtlil.h"
+#include "kernel/log.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+int current_iobank = 0;
+
+// IO Banks that are present on the device.
+// This is very part specific and is for Arty's xc7a35tcsg324 part.
+std::vector<int> io_banks = {14, 15, 16, 34, 35};
+
+enum SetPropertyOptions { INTERNAL_VREF };
+
+std::unordered_map<std::string, SetPropertyOptions> set_property_options_map  = {
+	{"INTERNAL_VREF", INTERNAL_VREF}
+};
+
+struct GetPorts : public Pass {
+	GetPorts() : Pass("get_ports", "Print matching ports") {}
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("   get_ports \n");
+		log("\n");
+		log("Get matching ports\n");
+		log("\n");
+		log("Print the output to stdout too. This is useful when all Yosys is executed\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design*) YS_OVERRIDE
+	{
+		std::string text;
+		for (auto& arg : args) {
+			text += arg + ' ';
+		}
+		if (!text.empty()) text.resize(text.size()-1);
+		log("%s\n", text.c_str());
+	}
+} GetPorts;
+
+struct GetIOBanks : public Pass {
+	GetIOBanks() : Pass("get_iobanks", "Set IO Bank number") {}
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("   get_iobanks \n");
+		log("\n");
+		log("Get IO Bank number\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design* ) YS_OVERRIDE
+	{
+		if (args.size() != 2) {
+			log("Incorrect number of arguments. %zu instead of 1", args.size());
+			return;
+		}
+		current_iobank = std::atoi(args[1].c_str());
+		if (std::find(io_banks.begin(), io_banks.end(), current_iobank) == io_banks.end()) {
+			log("get_iobanks: Incorrect bank number: %d\n", current_iobank);
+			current_iobank = 0;
+		}
+	}
+} GetIOBanks;
+
+struct SetProperty : public Pass {
+	SetProperty() : Pass("set_property", "Set a given property") {}
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    set_property PROPERTY VALUE OBJECT\n");
+		log("\n");
+		log("Set the given property to the specified value on an object\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design* design) YS_OVERRIDE
+	{
+		if (design->top_module() == nullptr) {
+			log("No top module detected\n");
+			return;
+		}
+
+		std::string option(args[1]);
+		if (set_property_options_map.count(option) == 0) {
+			log("set_property: %s option is currently not supported\n", option.c_str());
+			return;
+		}
+
+		switch (set_property_options_map[option]) {
+			case INTERNAL_VREF:
+				process_vref(std::vector<std::string>(args.begin() + 2, args.end()), design);
+				break;
+			default:
+				assert(false);
+		}
+	}
+	void process_vref(std::vector<std::string> args, RTLIL::Design* design)
+       	{
+		if (args.size() != 2) {
+			log("set_property INTERNAL_VREF: Incorrect number of arguments: %zu\n", args.size());
+			return;
+		}
+
+		if (current_iobank == 0) {
+			log("set_property INTERNAL_VREF: No valid bank set. Use get_iobanks.\n");
+			return;
+		}
+
+		int internal_vref = 1000 * std::atof(args[0].c_str());
+		if (internal_vref != 600 &&
+				internal_vref != 675 &&
+				internal_vref != 750 &&
+				internal_vref != 900) {
+			log("set_property INTERNAL_VREF: Incorrect INTERNAL_VREF value\n");
+			return;
+		}
+
+		// Create a new BANK module if it hasn't been created so far
+		RTLIL::Module* top_module = design->top_module();
+		if (!design->has(ID(BANK))) {
+			RTLIL::Module* bank_module = design->addModule(ID(BANK));
+			bank_module->makeblackbox();
+			bank_module->avail_parameters.insert(ID(NUMBER));
+			bank_module->avail_parameters.insert(ID(INTERNAL_VREF));
+		}
+
+		// Set parameters on a new bank instance or update an existing one
+		char bank_cell_name[16];
+		snprintf(bank_cell_name, 16, "\\bank_cell_%d", current_iobank);
+		RTLIL::Cell* bank_cell = top_module->cell(RTLIL::IdString(bank_cell_name));
+		if (!bank_cell) {
+			bank_cell = top_module->addCell(RTLIL::IdString(bank_cell_name), ID(BANK));
+		}
+		bank_cell->setParam(ID(NUMBER), RTLIL::Const(current_iobank));
+		bank_cell->setParam(ID(INTERNAL_VREF), RTLIL::Const(internal_vref));
+	}
+
+} SetProperty;
+
+PRIVATE_NAMESPACE_END

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -188,11 +188,8 @@ struct SetProperty : public Pass {
 		// Create a new BANK module if it hasn't been created so far
 		RTLIL::Module* top_module = design->top_module();
 		if (!design->has(ID(BANK))) {
-			RTLIL::Module* bank_module = design->addModule(ID(BANK));
-			bank_module->makeblackbox();
-			bank_module->avail_parameters.insert(ID(FASM_EXTRA));
-			bank_module->avail_parameters.insert(ID(NUMBER));
-			bank_module->avail_parameters.insert(ID(INTERNAL_VREF));
+			std::string fasm_extra_modules_dir(proc_share_dirname() + "/plugins/fasm_extra_modules");
+			Pass::call(design, "read_verilog " + fasm_extra_modules_dir + "/BANK.v");
 		}
 
 		// Set parameters on a new bank instance or update an existing one


### PR DESCRIPTION
The initial versions of the plugins are capable of reading an XDC file with the INTERNAL_VREF settings and generating a FASM file with the features that we currently have in our database that are related to the VREF settings per bank.
This plugin operates on the existing design and modifies its structure based on the content of the XDC (Xilinx Design Constraints) file.
Since the XDC file consists of Tcl commands it is read using Yosys's tcl command and processed by the new XDC commands imported to the Tcl interpreter.

To use the plugins which are compiled as shared libraries they need to be copied to `share/yosys/plugins/` directory and later on in the yosys script they should be loaded with the `plugin command`

The information about available IO banks for a specific part and what tiles they map to will be taken from the part's json.
The file is passed to read_xdc and write_fasm commands via `-json_part` switch and should contain an `iobanks` entry, e.g.:
<pre>
    "iobanks": {
        "14" : "X1Y26",
        "15" : "X1Y78",
        "16" : "X1Y130",
        "34" : "X113Y26",
        "35" : "X113Y78"
    }
</pre>

This information is used during writing out the fasm file as well as for error checking during read_xdc.

Example of Yosys script:
<pre>
plugin -i fasm
plugin -i xdc
read_verilog counter_arty.v
read_xdc -part_json xc7a35tcsg324-1.json arty.xdc
write_fasm -part_json xc7a35tcsg324-1.json counter_arty.fasm
</pre>

In order to merge it to symbiflow-arch-defs I will have to create a conda package and copy the plugins to yosys's environment. 
The next step will be modifying the synthesis script we use in arch-defs
Finally, add a fasm concatenation step that will combine the output of the fasm plugin and the outcome of genfasm to produce the complete FASM.