### PR TITLE
Annotate verilog with XDC parameters.

### DIFF
--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -44,12 +44,13 @@ static bool isOutputPort(RTLIL::Wire* wire) {
 	return wire->port_output;
 }
 
-enum class SetPropertyOptions { INTERNAL_VREF, IOSTANDARD, SLEW, IN_TERM };
+enum class SetPropertyOptions { INTERNAL_VREF, IOSTANDARD, SLEW, DRIVE, IN_TERM };
 
 const std::unordered_map<std::string, SetPropertyOptions> set_property_options_map  = {
 	{"INTERNAL_VREF", SetPropertyOptions::INTERNAL_VREF},
 	{"IOSTANDARD", SetPropertyOptions::IOSTANDARD},
 	{"SLEW", SetPropertyOptions::SLEW},
+	{"DRIVE", SetPropertyOptions::DRIVE},
 	{"IN_TERM", SetPropertyOptions::IN_TERM}
 };
 
@@ -174,6 +175,7 @@ struct SetProperty : public Pass {
 				break;
 			case SetPropertyOptions::IOSTANDARD:
 			case SetPropertyOptions::SLEW:
+			case SetPropertyOptions::DRIVE:
 			case SetPropertyOptions::IN_TERM:
 				process_port_parameter(std::vector<std::string>(args.begin() + 1, args.end()), design);
 				break;

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -97,14 +97,16 @@ struct GetPorts : public Pass {
 
 		RTLIL::IdString port_id(RTLIL::escape_id(port_signal.c_str()));
 		if (auto wire = top_module->wire(port_id)) {
-			if (isInputPort(wire) || isOutputPort(wire)) {
-				Tcl_Interp *interp = yosys_get_tcl_interp();
-				Tcl_SetResult(interp, const_cast<char*>(port_name.c_str()), NULL);
-				log("Found port %s\n", port_name.c_str());
-				return;
+			if (bit >= wire->start_offset && bit < wire->start_offset + wire->width) {
+				if (isInputPort(wire) || isOutputPort(wire)) {
+					Tcl_Interp *interp = yosys_get_tcl_interp();
+					Tcl_SetResult(interp, const_cast<char*>(port_name.c_str()), NULL);
+					log("Found port %s\n", port_name.c_str());
+					return;
+				}
 			}
 		}
-		log_warning("Couldn't find port %s\n", port_name.c_str());
+		log_error("Couldn't find port %s\n", port_name.c_str());
 	}
 	std::string port_name;
 };
@@ -227,7 +229,7 @@ struct SetProperty : public Pass {
 			log_error("set_property: Incorrect number of arguments.\n");
 		}
 		std::string parameter(args.at(0));
-		if (args.size() < 3) {
+		if (args.size() < 3 || args.at(2).size() == 0) {
 			log_error("set_property %s: Incorrect number of arguments.\n", parameter.c_str());
 		}
 		std::string port_name(args.at(2));


### PR DESCRIPTION
This PR annotates the design read from verilog with IOSTANDARD, SLEW, DRIVE and IN_TERM parameters read from XDC.
Currently only single bit ports are supported.
However we need to handle bus ports for Litex.