### PR TITLE
Cell counting plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_LIST := fasm xdc params selection sdc
+PLUGIN_LIST := fasm xdc params selection sdc get_count
 PLUGINS := $(foreach plugin,$(PLUGIN_LIST),$(plugin).so)
 PLUGINS_INSTALL := $(foreach plugin,$(PLUGIN_LIST),install_$(plugin))
 PLUGINS_CLEAN := $(foreach plugin,$(PLUGIN_LIST),clean_$(plugin))

--- a/get_count-plugin/Makefile
+++ b/get_count-plugin/Makefile
@@ -1,0 +1,24 @@
+CXX = $(shell yosys-config --cxx)
+CXXFLAGS = $(shell yosys-config --cxxflags)
+LDFLAGS = $(shell yosys-config --ldflags)
+LDLIBS = $(shell yosys-config --ldlibs)
+PLUGINS_DIR = $(shell yosys-config --datdir)/plugins
+
+NAME = get_count
+OBJS = $(NAME).o
+
+$(NAME).so: $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
+
+.PHONY: install test
+
+install: test
+	mkdir -p $(PLUGINS_DIR)
+	cp $(NAME).so $(PLUGINS_DIR)/$(NAME).so
+
+test: $(NAME).so
+	$(MAKE) -C tests all
+
+clean:
+	rm -f *.d *.o *.so
+	$(MAKE) -C tests clean

--- a/get_count-plugin/Makefile
+++ b/get_count-plugin/Makefile
@@ -12,7 +12,7 @@ $(NAME).so: $(OBJS)
 
 .PHONY: install test
 
-install: test
+install: $(NAME).so
 	mkdir -p $(PLUGINS_DIR)
 	cp $(NAME).so $(PLUGINS_DIR)/$(NAME).so
 

--- a/get_count-plugin/get_count.cc
+++ b/get_count-plugin/get_count.cc
@@ -1,0 +1,133 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *  Copyright (C) 2020  The Symbiflow Authors
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/register.h"
+#include "kernel/rtlil.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+void register_in_tcl_interpreter(const std::string& command) {
+    Tcl_Interp* interp = yosys_get_tcl_interp();
+    std::string tcl_script = stringf("proc %s args { return [yosys %s {*}$args] }", command.c_str(), command.c_str());
+    Tcl_Eval(interp, tcl_script.c_str());
+}
+
+struct GetCount : public Pass {
+
+    enum class ObjectType {
+        NONE,
+        MODULE,
+        CELL,
+        WIRE
+    };
+
+    GetCount () :
+        Pass("get_count", "Returns count of various selected object types to the TCL interpreter") {
+            register_in_tcl_interpreter(pass_name);
+        }    
+
+    void help() YS_OVERRIDE {
+        log("\n");
+        log("    get_count <options> [selection]");
+        log("\n");
+        log("When used from inside the TCL interpreter returns count of selected objects.\n");
+        log("The object type to count may be given as an argument. Only one at a time.\n");
+        log("If none is given then the total count of all selected objects is returned.\n");
+        log("\n");
+        log("    -modules\n");
+        log("        Returns the count of modules in selection\n");
+        log("\n");
+        log("    -cells\n");
+        log("        Returns the count of cells in selection\n");
+        log("\n");
+        log("    -wires\n");
+        log("        Returns the count of wires in selection\n");
+        log("\n");
+    }
+    
+    void execute(std::vector<std::string> a_Args, RTLIL::Design* a_Design) YS_OVERRIDE {
+
+        // Parse args
+        ObjectType type = ObjectType::NONE;
+        if (a_Args.size() < 2) {
+            log_error("Invalid argument!\n");
+        }
+
+        if (a_Args[1] == "-modules") {
+            type = ObjectType::MODULE;
+        }
+        else if (a_Args[1] == "-cells") {
+            type = ObjectType::CELL;
+        }
+        else if (a_Args[1] == "-wires") {
+            type = ObjectType::WIRE;
+        }
+        else if (a_Args[1][0] == '-') {
+            log_error("Invalid argument '%s'!\n", a_Args[1].c_str());
+        }
+        else {
+            log_error("Object type not specified!\n");
+        }
+
+        extra_args(a_Args, 2, a_Design);
+
+        // Get the TCL interpreter
+        Tcl_Interp* tclInterp = yosys_get_tcl_interp();
+        Tcl_Obj*    tclList = Tcl_NewListObj(0, NULL);
+
+        // Count objects
+        size_t moduleCount = 0;
+        size_t cellCount   = 0;
+        size_t wireCount   = 0;
+
+        moduleCount += a_Design->selected_modules().size();
+        for (auto module : a_Design->selected_modules()) {
+            cellCount += module->selected_cells().size();
+            wireCount += module->selected_wires().size();
+        }
+
+        size_t count = 0;
+        switch (type)
+        {
+        case ObjectType::MODULE:
+            count = moduleCount;
+            break;
+        case ObjectType::CELL:
+            count = cellCount;
+            break;
+        case ObjectType::WIRE:
+            count = wireCount;
+            break;
+        default:
+            log_assert(false);
+        }
+
+        // Return the value as string to the TCL interpreter
+        std::string value = std::to_string(count);
+
+        Tcl_Obj* tclStr = Tcl_NewStringObj(value.c_str(), value.size());
+        Tcl_ListObjAppendElement(tclInterp, tclList, tclStr);
+        Tcl_SetObjResult(tclInterp, tclList);
+    }
+
+} GetCount;
+
+PRIVATE_NAMESPACE_END

--- a/get_count-plugin/get_count.cc
+++ b/get_count-plugin/get_count.cc
@@ -21,6 +21,10 @@
 #include "kernel/register.h"
 #include "kernel/rtlil.h"
 
+#ifndef YS_OVERRIDE
+#define YS_OVERRIDE override
+#endif
+
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 

--- a/get_count-plugin/get_count.cc
+++ b/get_count-plugin/get_count.cc
@@ -28,12 +28,6 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-void register_in_tcl_interpreter(const std::string& command) {
-    Tcl_Interp* interp = yosys_get_tcl_interp();
-    std::string tcl_script = stringf("proc %s args { return [yosys %s {*}$args] }", command.c_str(), command.c_str());
-    Tcl_Eval(interp, tcl_script.c_str());
-}
-
 struct GetCount : public Pass {
 
     enum class ObjectType {
@@ -45,7 +39,6 @@ struct GetCount : public Pass {
 
     GetCount () :
         Pass("get_count", "Returns count of various selected object types to the TCL interpreter") {
-            register_in_tcl_interpreter(pass_name);
         }    
 
     void help() YS_OVERRIDE {
@@ -95,7 +88,6 @@ struct GetCount : public Pass {
 
         // Get the TCL interpreter
         Tcl_Interp* tclInterp = yosys_get_tcl_interp();
-        Tcl_Obj*    tclList = Tcl_NewListObj(0, NULL);
 
         // Count objects
         size_t moduleCount = 0;
@@ -128,8 +120,7 @@ struct GetCount : public Pass {
         std::string value = std::to_string(count);
 
         Tcl_Obj* tclStr = Tcl_NewStringObj(value.c_str(), value.size());
-        Tcl_ListObjAppendElement(tclInterp, tclList, tclStr);
-        Tcl_SetObjResult(tclInterp, tclList);
+        Tcl_SetObjResult(tclInterp, tclStr);
     }
 
 } GetCount;

--- a/get_count-plugin/tests/Makefile
+++ b/get_count-plugin/tests/Makefile
@@ -1,0 +1,15 @@
+TESTS = $(subst /, ,$(wildcard */))
+
+all: $(addsuffix /ok,$(TESTS))
+
+clean:
+	@find . -name "ok" | xargs rm -rf
+
+define maketest =
+$1/ok:
+	cd $1 && $(MAKE) test
+endef
+
+$(foreach _,${TESTS},$(eval $(call maketest,$_)))
+
+.PHONY: all clean

--- a/get_count-plugin/tests/Makefile
+++ b/get_count-plugin/tests/Makefile
@@ -1,6 +1,6 @@
 TESTS = $(subst /, ,$(wildcard */))
 
-all: $(addsuffix /ok,$(TESTS))
+all: clean $(addsuffix /ok,$(TESTS))
 
 clean:
 	@find . -name "ok" | xargs rm -rf

--- a/get_count-plugin/tests/simple/Makefile
+++ b/get_count-plugin/tests/simple/Makefile
@@ -1,0 +1,8 @@
+test:
+	yosys -p "tcl script.tcl"
+	touch ok
+
+clean:
+	rm -rf ok
+
+.PHONY: test clean

--- a/get_count-plugin/tests/simple/design.v
+++ b/get_count-plugin/tests/simple/design.v
@@ -1,0 +1,23 @@
+module my_gate (
+    input  wire A,
+    output wire Y
+);
+
+    assign Y = ~A;
+endmodule
+
+module top (
+    input  wire [7:0] di,
+    output wire [7:0] do
+);
+
+    my_gate c0 (.A(di[0]), .Y(do[0]));
+    \$_BUF_ c1 (.A(di[1]), .Y(do[1]));
+    \$_BUF_ c2 (.A(di[2]), .Y(do[2]));
+    \$_BUF_ c3 (.A(di[3]), .Y(do[3]));
+    \$_BUF_ c4 (.A(di[4]), .Y(do[4]));
+    \$_NOT_ c5 (.A(di[5]), .Y(do[5]));
+    \$_NOT_ c6 (.A(di[6]), .Y(do[6]));
+    \$_NOT_ c7 (.A(di[7]), .Y(do[7]));
+
+endmodule

--- a/get_count-plugin/tests/simple/script.tcl
+++ b/get_count-plugin/tests/simple/script.tcl
@@ -1,0 +1,30 @@
+yosys plugin -i ../../get_count.so
+yosys -import
+
+read_verilog -icells design.v
+hierarchy -auto-top
+
+set n [get_count -modules my_gate]
+puts "Module count: $n"
+if {$n != "1"} {
+    error "Invalid count"
+}
+
+set n [get_count -cells t:\$_BUF_]
+puts "BUF count: $n"
+if {$n != "4"} {
+    error "Invalid count"
+}
+
+set n [get_count -cells t:\$_NOT_]
+puts "NOT count: $n"
+if {$n != "3"} {
+    error "Invalid count"
+}
+
+set n [get_count -wires w:*]
+puts "Wire count: $n"
+if {$n != "5"} {
+    error "Invalid count"
+}
+

--- a/get_count-plugin/tests/simple/script.tcl
+++ b/get_count-plugin/tests/simple/script.tcl
@@ -1,4 +1,4 @@
-yosys plugin -i ../../get_count.so
+yosys plugin -i get_count
 yosys -import
 
 read_verilog -icells design.v


### PR DESCRIPTION
This is a plugin that allows to return to the TCL interpreter number of selected modules, cells or wires. It is used in synthesis script for QuickLogic FPGAs.