### PR TITLE
Write sdc multiple pass

### DIFF
--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -73,6 +73,9 @@ class Clocks {
     const std::vector<Clock> GetClocks() {
 	return clocks_;
     }
+    void Clear() {
+	clocks_.clear();
+    }
 
    private:
     std::vector<Clock> clocks_;

--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -11,7 +11,8 @@ TESTS = counter \
 	pll_approx_equal \
 	set_false_path \
 	set_max_delay \
-	set_clock_groups
+	set_clock_groups \
+	multiple_passes
 
 include $(shell pwd)/../../Makefile_test.common
 
@@ -24,3 +25,4 @@ pll_approx_equal_verify = $(call diff_test,pll_approx_equal,sdc)
 set_false_path_verify = $(call diff_test,set_false_path,sdc)
 set_max_delay_verify = $(call diff_test,set_max_delay,sdc)
 set_clock_groups_verify = $(call diff_test,set_clock_groups,sdc)
+multiple_passes_verify = diff multiple_passes/multiple_passes_1.sdc multiple_passes/multiple_passes_2.sdc

--- a/sdc-plugin/tests/counter/counter.golden.txt
+++ b/sdc-plugin/tests/counter/counter.golden.txt
@@ -1,1 +1,1 @@
-clk_int_1 clk ibuf_proxy_out {$auto$clkbufmap.cc:247:execute$1918} {$auto$clkbufmap.cc:247:execute$1920} middle_inst_1.clk_int middle_inst_4.clk
+clk_int_1 clk

--- a/sdc-plugin/tests/counter/counter.tcl
+++ b/sdc-plugin/tests/counter/counter.tcl
@@ -13,9 +13,6 @@ synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 # Read the design's timing constraints
 read_sdc $::env(DESIGN_TOP).input.sdc
 
-# Propagate the clocks
-propagate_clocks
-
 # Write the clocks to file
 set fh [open $::env(DESIGN_TOP).txt w]
 set clocks [get_clocks]

--- a/sdc-plugin/tests/counter2/counter2.golden.txt
+++ b/sdc-plugin/tests/counter2/counter2.golden.txt
@@ -1,1 +1,1 @@
-clk_int_1 clk clk2 ibuf_proxy_out {$auto$clkbufmap.cc:247:execute$1918} {$auto$clkbufmap.cc:247:execute$1920} middle_inst_1.clk_int middle_inst_4.clk
+clk_int_1 clk clk2

--- a/sdc-plugin/tests/counter2/counter2.tcl
+++ b/sdc-plugin/tests/counter2/counter2.tcl
@@ -13,9 +13,6 @@ synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 # Read the design's timing constraints
 read_sdc $::env(DESIGN_TOP).input.sdc
 
-# Propagate the clocks
-propagate_clocks
-
 # Write the clocks to file
 set fh [open $::env(DESIGN_TOP).txt w]
 set clocks [get_clocks]

--- a/sdc-plugin/tests/multiple_passes/multiple_passes.tcl
+++ b/sdc-plugin/tests/multiple_passes/multiple_passes.tcl
@@ -1,0 +1,17 @@
+yosys -import
+
+plugin -i sdc
+
+yosys -import
+
+read_verilog $::env(DESIGN_TOP).v
+synth_xilinx
+create_clock -period 10 clk
+write_sdc $::env(DESIGN_TOP)_1.sdc
+write_json $::env(DESIGN_TOP).json
+
+design -push
+
+read_json $::env(DESIGN_TOP).json
+create_clock -period 10 clk
+write_sdc $::env(DESIGN_TOP)_2.sdc

--- a/sdc-plugin/tests/multiple_passes/multiple_passes.v
+++ b/sdc-plugin/tests/multiple_passes/multiple_passes.v
@@ -1,0 +1,11 @@
+module top(input clk, input i, output o);
+
+reg [0:0] outff = 0;
+
+assign o = outff;
+
+always @(posedge clk) begin
+    outff <= i;
+end
+
+endmodule

--- a/sdc-plugin/tests/pll/pll.tcl
+++ b/sdc-plugin/tests/pll/pll.tcl
@@ -14,8 +14,5 @@ synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 # Read the design timing constraints
 read_sdc $::env(DESIGN_TOP).input.sdc
 
-# Propagate the clocks
-propagate_clocks
-
 # Write out the SDC file after the clock propagation step
 write_sdc $::env(DESIGN_TOP).sdc

--- a/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.tcl
+++ b/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.tcl
@@ -14,8 +14,5 @@ synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 # Read the design timing constraints
 read_sdc $::env(DESIGN_TOP).input.sdc
 
-# Propagate the clocks
-propagate_clocks
-
 # Write out the SDC file after the clock propagation step
 write_sdc $::env(DESIGN_TOP).sdc

--- a/sdc-plugin/tests/pll_div/pll_div.tcl
+++ b/sdc-plugin/tests/pll_div/pll_div.tcl
@@ -14,8 +14,5 @@ synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 # Read the design timing constraints
 read_sdc $::env(DESIGN_TOP).input.sdc
 
-# Propagate the clocks
-propagate_clocks
-
 # Write out the SDC file after the clock propagation step
 write_sdc $::env(DESIGN_TOP).sdc

--- a/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.tcl
+++ b/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.tcl
@@ -14,8 +14,5 @@ synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 # Read the design timing constraints
 read_sdc $::env(DESIGN_TOP).input.sdc
 
-# Propagate the clocks
-propagate_clocks
-
 # Write out the SDC file after the clock propagation step
 write_sdc $::env(DESIGN_TOP).sdc


### PR DESCRIPTION
This PR present a possible fix for the bug reported in issue #45.
It creates a `write_sdc` script pass command which wraps the `propagate_clocks` and write_sdc` commands effectively postponing the clock propagation to happen when `write_sdc` is called, right before actaully writing out the final SDC file.