### PR TITLE
Add -through switch to set_false_path command

### DIFF
--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -71,6 +71,9 @@ void SdcWriter::WriteFalsePaths(std::ostream& file) {
 	if (!path.from_pin.empty()) {
 	    file << " -from " << path.from_pin;
 	}
+	if (!path.through_pin.empty()) {
+	    file << " -through " << path.through_pin;
+	}
 	if (!path.to_pin.empty()) {
 	    file << " -to " << path.to_pin;
 	}

--- a/sdc-plugin/sdc_writer.h
+++ b/sdc-plugin/sdc_writer.h
@@ -25,6 +25,7 @@ USING_YOSYS_NAMESPACE
 struct FalsePath {
     std::string from_pin;
     std::string to_pin;
+    std::string through_pin;
 };
 
 struct TimingPath {

--- a/sdc-plugin/set_false_path.cc
+++ b/sdc-plugin/set_false_path.cc
@@ -41,6 +41,9 @@ void SetFalsePath::help() {
     log("    -to\n");
     log("        List of end points or clocks.\n");
     log("\n");
+    log("    -through\n");
+    log("        List of through points or clocks.\n");
+    log("\n");
 }
 
 void SetFalsePath::execute(std::vector<std::string> args,
@@ -54,6 +57,7 @@ void SetFalsePath::execute(std::vector<std::string> args,
     bool is_quiet = false;
     std::string from_pin;
     std::string to_pin;
+    std::string through_pin;
 
     // Parse command arguments
     for (argidx = 1; argidx < args.size(); argidx++) {
@@ -65,13 +69,16 @@ void SetFalsePath::execute(std::vector<std::string> args,
 
 	if (arg == "-from" and argidx + 1 < args.size()) {
 	    from_pin = args[++argidx];
-	    log("From: %s\n", from_pin.c_str());
 	    continue;
 	}
 
 	if (arg == "-to" and argidx + 1 < args.size()) {
 	    to_pin = args[++argidx];
-	    log("To: %s\n", to_pin.c_str());
+	    continue;
+	}
+
+	if (arg == "-through" and argidx + 1 < args.size()) {
+	    through_pin = args[++argidx];
 	    continue;
 	}
 
@@ -83,8 +90,10 @@ void SetFalsePath::execute(std::vector<std::string> args,
     }
     if (!is_quiet) {
 	std::string msg = (from_pin.empty()) ? "" : "-from " + from_pin;
+	msg += (through_pin.empty()) ? "" : " -through " + through_pin;
 	msg += (to_pin.empty()) ? "" : " -to " + to_pin;
 	log("Adding false path %s\n", msg.c_str());
     }
-    sdc_writer_.AddFalsePath(FalsePath{.from_pin = from_pin, .to_pin = to_pin});
+    sdc_writer_.AddFalsePath(FalsePath{
+        .from_pin = from_pin, .to_pin = to_pin, .through_pin = through_pin});
 }

--- a/sdc-plugin/tests/set_false_path/set_false_path.golden.sdc
+++ b/sdc-plugin/tests/set_false_path/set_false_path.golden.sdc
@@ -1,3 +1,4 @@
 set_false_path -to inter_wire
 set_false_path -from clk
 set_false_path -from clk -to bottom_inst.I
+set_false_path -through bottom_inst.I

--- a/sdc-plugin/tests/set_false_path/set_false_path.tcl
+++ b/sdc-plugin/tests/set_false_path/set_false_path.tcl
@@ -16,4 +16,7 @@ set_false_path -quiet -from clk
 # -from clk to bottom_inst/I
 set_false_path -from clk -to bottom_inst.I
 
+# -through bottom_inst/I
+set_false_path -through bottom_inst.I
+
 write_sdc $::env(DESIGN_TOP).sdc


### PR DESCRIPTION
The XDC file generated for the base litex design contains the following command:
```
set_false_path -quiet -through [get_nets -hierarchical -filter {mr_ff == TRUE}]
```
While we do have the `set_false_path` command already implemented we are missing the `through` switch.
This PR addressed that.