### PR TITLE
Keep the SDC information in Yosys's design structures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/googletest"]
+	path = third_party/googletest
+	url = https://github.com/google/googletest

--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -37,7 +37,7 @@
 # |-- example2-plugin
 # |-- ...
 CXX = $(shell yosys-config --cxx)
-CXXFLAGS = $(shell yosys-config --cxxflags)
+CXXFLAGS = $(shell yosys-config --cxxflags) #-DSDC_DEBUG
 LDFLAGS = $(shell yosys-config --ldflags)
 LDLIBS = $(shell yosys-config --ldlibs)
 PLUGINS_DIR = $(shell yosys-config --datdir)/plugins

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -12,6 +12,12 @@
 # test1_verify = $(call diff_test,test1,ext) && test $$(grep "PASS" test1/test1.txt | wc -l) -eq 2
 # test2_verify = $(call diff_test,test2,ext)
 #
+GTEST_DIR = ../../third_party/googletest/googletest
+CXX = $(shell yosys-config --cxx)
+CXXFLAGS = $(shell yosys-config --cxxflags) -I.. -I$(GTEST_DIR)/include
+LDLIBS = $(shell yosys-config --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
+LDFLAGS = $(shell yosys-config --ldflags)
+
 define test_tpl =
 $(1): $(1)/ok
 	@echo "Verifying result of test $(1)"
@@ -50,13 +56,34 @@ $(1)/ok: $(1)/$(1).v
 
 endef
 
+define unit_test_tpl =
+$(1): $(1)/$(1).test
+	@$$<
+
+$(1)/$(1).test: $(1)/$(1).test.o $$(GTEST_DIR)/build/lib/libgtest.a
+	@$(CXX) $(LDFLAGS) -o $$@ $$< $(LDLIBS)
+
+$(1)/$(1).test.o: $(1)/$(1).test.cc
+	@$(CXX) $(CXXFLAGS) $(LDFLAGS) -c $$< -o $$@
+
+endef
+
 diff_test = diff $(1)/$(1).golden.$(2) $(1)/$(1).$(2)
 
-all: $(TESTS)
-.PHONY: all clean $(TESTS)
+all: $(TESTS) $(UNIT_TESTS)
+
+$(GTEST_DIR)/build/lib/libgtest.a $(GTEST_DIR)/build/lib/libgtest_main.a:
+	@mkdir -p $(GTEST_DIR)/build
+	@cd $(GTEST_DIR)/build; \
+	cmake ..; \
+	make
+
+.PHONY: all clean $(TESTS) $(UNIT_TESTS)
 
 $(foreach test,$(TESTS),$(eval $(call test_tpl,$(test))))
+$(foreach test,$(UNIT_TESTS),$(eval $(call unit_test_tpl,$(test))))
 
 clean:
 	@rm -rf $(foreach test,$(TESTS),$(test)/$(test).sdc $(test)/$(test).txt $(test)/$(test).eblif $(test)/$(test).json)
+	@rm -rf $(foreach test,$(UNIT_TESTS),$(test)/$(test).test.o $(test)/$(test).test.d $(test)/$(test).test)
 	@find . -name "ok" -or -name "*.log" | xargs rm -rf

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -33,7 +33,7 @@ $(1)/ok: $(1)/$(1).v
 
 endef
 
-diff_test = bash -c "diff <(sort $(1)/$(1).golden.$(2)) <(sort $(1)/$(1).$(2))"
+diff_test = diff $(1)/$(1).golden.$(2) $(1)/$(1).$(2)
 
 all: $(TESTS)
 .PHONY: all clean $(TESTS)

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -14,9 +14,10 @@
 #
 define test_tpl =
 $(1): $(1)/ok
-	@$$($(1)_verify); \
-	RETVAL=$$$$? ; \
-	if [ $$$$RETVAL -eq 0 ]; then \
+	@echo "Verifying result of test $(1)"
+	@set +e; \
+	$$($(1)_verify); \
+	if [ $$$$? -eq 0 ]; then \
 		echo "Test $(1) PASSED"; \
 		touch $$<; \
 		true; \
@@ -27,9 +28,25 @@ $(1): $(1)/ok
 
 $(1)/ok: $(1)/$(1).v
 	@echo "Running test $(1)"
-	@cd $(1); \
+	@set +e; \
+	cd $(1); \
 	DESIGN_TOP=$(1) \
-	yosys -c $(1).tcl -q -l $(1).log
+	yosys -c $(1).tcl -q -l $(1).log; \
+	RETVAL=$$$$?; \
+	if [ ! -z "$$($(1)_negative)" ] && [ $$($(1)_negative) -eq 1 ]; then \
+		if [ $$$$RETVAL -ne 0 ]; then \
+			echo "Negative test $(1) PASSED"; \
+			true; \
+		else \
+			echo "Negative test $(1) FAILED"; \
+			false; \
+		fi \
+	else \
+		if [ $$$$RETVAL -ne 0 ]; then \
+			echo "Unexpected runtime error"; \
+			false; \
+		fi \
+	fi
 
 endef
 

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -33,7 +33,7 @@ $(1)/ok: $(1)/$(1).v
 
 endef
 
-diff_test = diff $(1)/$(1).golden.$(2) $(1)/$(1).$(2)
+diff_test = bash -c "diff <(sort $(1)/$(1).golden.$(2)) <(sort $(1)/$(1).$(2))"
 
 all: $(TESTS)
 .PHONY: all clean $(TESTS)

--- a/sdc-plugin/buffers.cc
+++ b/sdc-plugin/buffers.cc
@@ -15,9 +15,9 @@
  *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
+#include "buffers.h"
 #include <cassert>
 #include <cmath>
-#include "buffers.h"
 
 const std::vector<std::string> Pll::inputs = {"CLKIN1", "CLKIN2"};
 const std::vector<std::string> Pll::outputs = {"CLKOUT0", "CLKOUT1", "CLKOUT2",
@@ -25,9 +25,9 @@ const std::vector<std::string> Pll::outputs = {"CLKOUT0", "CLKOUT1", "CLKOUT2",
 const float Pll::delay = 0;
 const std::string Pll::name = "PLLE2_ADV";
 
-Pll::Pll(RTLIL::Cell* cell, float input_clock_period, float input_clock_rising_edge)
- : ClockDivider({"PLLE2_ADV"})
-{
+Pll::Pll(RTLIL::Cell* cell, float input_clock_period,
+         float input_clock_rising_edge)
+    : ClockDivider({"PLLE2_ADV"}) {
     assert(RTLIL::unescape_id(cell->type) == "PLLE2_ADV");
     FetchParams(cell);
     CheckInputClockPeriod(cell, input_clock_period);
@@ -37,7 +37,9 @@ Pll::Pll(RTLIL::Cell* cell, float input_clock_period, float input_clock_rising_e
 
 void Pll::CheckInputClockPeriod(RTLIL::Cell* cell, float input_clock_period) {
     float abs_diff = fabs(ClkinPeriod() - input_clock_period);
-    bool approx_equal = abs_diff < std::max(ClkinPeriod(), input_clock_period) * 10 * std::numeric_limits<float>::epsilon();
+    bool approx_equal = abs_diff < std::max(ClkinPeriod(), input_clock_period) *
+                                       10 *
+                                       std::numeric_limits<float>::epsilon();
     if (!approx_equal) {
 	log_cmd_error(
 	    "CLKIN[1/2]_PERIOD doesn't match the virtual clock constraint "
@@ -55,7 +57,8 @@ void Pll::FetchParams(RTLIL::Cell* cell) {
     divclk_divisor = FetchParam(cell, "DIVCLK_DIVIDE", 1.0);
     for (auto output : outputs) {
 	// CLKOUT[0-5]_DUTY_CYCLE
-	clkout_duty_cycle[output] = FetchParam(cell, output + "_DUTY_CYCLE", 0.5);
+	clkout_duty_cycle[output] =
+	    FetchParam(cell, output + "_DUTY_CYCLE", 0.5);
 	// CLKOUT[0-5]_DIVIDE
 	clkout_divisor[output] = FetchParam(cell, output + "_DIVIDE", 1.0);
 	// CLKOUT[0-5]_PHASE
@@ -65,22 +68,30 @@ void Pll::FetchParams(RTLIL::Cell* cell) {
 
 void Pll::CalculateOutputClockPeriods() {
     for (auto output : outputs) {
-	// CLKOUT[0-5]_PERIOD = CLKIN1_PERIOD * CLKOUT[0-5]_DIVIDE * DIVCLK_DIVIDE /
-	// CLKFBOUT_MULT
-	clkout_period[output] = ClkinPeriod() * clkout_divisor.at(output) / clk_mult *
-	    divclk_divisor;
+	// CLKOUT[0-5]_PERIOD = CLKIN1_PERIOD * CLKOUT[0-5]_DIVIDE *
+	// DIVCLK_DIVIDE / CLKFBOUT_MULT
+	clkout_period[output] = ClkinPeriod() * clkout_divisor.at(output) /
+	                        clk_mult * divclk_divisor;
     }
 }
 
 void Pll::CalculateOutputClockWaveforms(float input_clock_rising_edge) {
     for (auto output : outputs) {
 	float output_clock_period = clkout_period.at(output);
-	clkout_rising_edge[output] = fmod(input_clock_rising_edge - (clk_fbout_phase / 360.0) * ClkinPeriod() + output_clock_period * (clkout_phase[output] / 360.0), output_clock_period);
-	clkout_falling_edge[output] = fmod(clkout_rising_edge[output] + clkout_duty_cycle[output] * output_clock_period, output_clock_period);
+	clkout_rising_edge[output] =
+	    fmod(input_clock_rising_edge -
+	             (clk_fbout_phase / 360.0) * ClkinPeriod() +
+	             output_clock_period * (clkout_phase[output] / 360.0),
+	         output_clock_period);
+	clkout_falling_edge[output] =
+	    fmod(clkout_rising_edge[output] +
+	             clkout_duty_cycle[output] * output_clock_period,
+	         output_clock_period);
     }
 }
 
-float Pll::FetchParam(RTLIL::Cell* cell, std::string&& param_name, float default_value) {
+float Pll::FetchParam(RTLIL::Cell* cell, std::string&& param_name,
+                      float default_value) {
     RTLIL::IdString param(RTLIL::escape_id(param_name));
     if (cell->hasParam(param)) {
 	auto param_obj = cell->parameters.at(param);

--- a/sdc-plugin/buffers.cc
+++ b/sdc-plugin/buffers.cc
@@ -25,7 +25,9 @@ const std::vector<std::string> Pll::outputs = {"CLKOUT0", "CLKOUT1", "CLKOUT2",
 const float Pll::delay = 0;
 const std::string Pll::name = "PLLE2_ADV";
 
-Pll::Pll(RTLIL::Cell* cell, float input_clock_period, float input_clock_rising_edge) {
+Pll::Pll(RTLIL::Cell* cell, float input_clock_period, float input_clock_rising_edge)
+ : ClockDivider({"PLLE2_ADV"})
+{
     assert(RTLIL::unescape_id(cell->type) == "PLLE2_ADV");
     FetchParams(cell);
     CheckInputClockPeriod(cell, input_clock_period);

--- a/sdc-plugin/buffers.h
+++ b/sdc-plugin/buffers.h
@@ -45,9 +45,10 @@ struct ClockDivider {
     std::string type;
 };
 
-struct Pll: public ClockDivider {
-    Pll():ClockDivider({"PLLE2_ADV"}){}
-    Pll(RTLIL::Cell* cell, float input_clock_period, float input_clock_rising_edge);
+struct Pll : public ClockDivider {
+    Pll() : ClockDivider({"PLLE2_ADV"}) {}
+    Pll(RTLIL::Cell* cell, float input_clock_period,
+        float input_clock_rising_edge);
 
     // Helper function to fetch a cell parameter or return a default value
     static float FetchParam(RTLIL::Cell* cell, std::string&& param_name,

--- a/sdc-plugin/buffers.h
+++ b/sdc-plugin/buffers.h
@@ -26,10 +26,10 @@
 USING_YOSYS_NAMESPACE
 
 struct Buffer {
-    Buffer(float delay, const std::string& name, const std::string& output)
-        : delay(delay), name(name), output(output) {}
+    Buffer(float delay, const std::string& type, const std::string& output)
+        : delay(delay), type(type), output(output) {}
     float delay;
-    std::string name;
+    std::string type;
     std::string output;
 };
 
@@ -41,7 +41,12 @@ struct Bufg : Buffer {
     Bufg() : Buffer(0, "BUFG", "O"){};
 };
 
-struct Pll {
+struct ClockDivider {
+    std::string type;
+};
+
+struct Pll: public ClockDivider {
+    Pll():ClockDivider({"PLLE2_ADV"}){}
     Pll(RTLIL::Cell* cell, float input_clock_period, float input_clock_rising_edge);
 
     // Helper function to fetch a cell parameter or return a default value

--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -55,23 +55,6 @@ const std::vector<RTLIL::Wire*> Clocks::GetClocks(RTLIL::Design* design) {
     return clock_wires;
 }
 
-std::vector<std::string> Clocks::GetClockNames() {
-    std::vector<std::string> res;
-    for (auto clock : clocks_) {
-	res.push_back(clock.Name());
-#ifdef SDC_DEBUG
-	std::stringstream ss;
-	for (auto clock_wire : clock.GetClockWires()) {
-	    ss << RTLIL::unescape_id(clock_wire->name) << " ";
-	}
-	log("create_clock -period %f -name %s -waveform {%f %f} %s\n",
-	    clock.Period(), clock.Name().c_str(), clock.RisingEdge(),
-	    clock.FallingEdge(), ss.str().c_str());
-#endif
-    }
-    return res;
-}
-
 void Clocks::Propagate(RTLIL::Design* design, NaturalPropagation* pass) {
 #ifdef SDC_DEBUG
     log("Start natural clock propagation\n");

--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -55,10 +55,16 @@ float Clock::Period(RTLIL::Wire* clock_wire) {
 	return 0;
     }
     float period(0);
+    std::string period_str;
     try {
-	period = std::stof(clock_wire->get_string_attribute(RTLIL::escape_id("PERIOD")));
+	period_str =
+	    clock_wire->get_string_attribute(RTLIL::escape_id("PERIOD"));
+	period = std::stof(period_str);
     } catch (const std::invalid_argument& e) {
-	log_cmd_error("Incorrect PERIOD format\n");
+	log_cmd_error(
+	    "Incorrect value '%s' specifed on PERIOD attribute for wire "
+	    "'%s'.\nPERIOD needs to be a float value.\n",
+	    period_str.c_str(), WireName(clock_wire).c_str());
     }
     return period;
 }
@@ -83,8 +89,13 @@ std::pair<float, float> Clock::Waveform(RTLIL::Wire* clock_wire) {
     float falling_edge(0);
     std::string waveform(
         clock_wire->get_string_attribute(RTLIL::escape_id("WAVEFORM")));
-    if (std::sscanf(waveform.c_str(), "%f %f", &rising_edge, &falling_edge) != 2) {
-	log_cmd_error("Incorrect WAVEFORM format\n");
+    if (std::sscanf(waveform.c_str(), "%f %f", &rising_edge, &falling_edge) !=
+        2) {
+	log_cmd_error(
+	    "Incorrect value '%s' specifed on WAVEFORM attribute for wire "
+	    "'%s'.\nWAVEFORM needs to be specified in form of '<rising_edge> "
+	    "<falling_edge>' where the edge values are floats.\n",
+	    waveform.c_str(), WireName(clock_wire).c_str());
     }
     return std::make_pair(rising_edge, falling_edge);
 }

--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -50,11 +50,8 @@ void Clock::Add(RTLIL::Wire* wire, float period, float rising_edge,
 
 float Clock::Period(RTLIL::Wire* clock_wire) {
     if (!clock_wire->has_attribute(RTLIL::escape_id("PERIOD"))) {
-	log_warning(
-	    "PERIOD has not been specified on wire '%s'.\nDefault value 0 will "
-	    "be used\n",
-	    WireName(clock_wire).c_str());
-	return 0;
+	log_cmd_error("PERIOD has not been specified on wire '%s'.\n",
+	              WireName(clock_wire).c_str());
     }
     float period(0);
     std::string period_str;

--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -51,7 +51,9 @@ void Clock::Add(RTLIL::Wire* wire, float period, float rising_edge,
 float Clock::Period(RTLIL::Wire* clock_wire) {
     if (!clock_wire->has_attribute(RTLIL::escape_id("PERIOD"))) {
 	log_warning(
-	    "Period has not been specified\n Default value 0 will be used\n");
+	    "PERIOD has not been specified on wire '%s'.\nDefault value 0 will "
+	    "be used\n",
+	    WireName(clock_wire).c_str());
 	return 0;
     }
     float period(0);
@@ -80,9 +82,9 @@ std::pair<float, float> Clock::Waveform(RTLIL::Wire* clock_wire) {
 	}
 	float falling_edge = period / 2;
 	log_warning(
-	    "Waveform has not been specified\n Default value {0 %f} will be "
-	    "used\n",
-	    falling_edge);
+	    "Waveform has not been specified on wire '%s'.\nDefault value {0 %f} "
+	    "will be used\n",
+	    WireName(clock_wire).c_str(), falling_edge);
 	return std::make_pair(0, falling_edge);
     }
     float rising_edge(0);
@@ -122,7 +124,8 @@ std::string Clock::WireName(RTLIL::Wire* wire) {
     return AddEscaping(RTLIL::unescape_id(wire->name));
 }
 
-const std::map<std::string, RTLIL::Wire*> Clocks::GetClocks(RTLIL::Design* design) {
+const std::map<std::string, RTLIL::Wire*> Clocks::GetClocks(
+    RTLIL::Design* design) {
     std::map<std::string, RTLIL::Wire*> clock_wires;
     RTLIL::Module* top_module = design->top_module();
     for (auto& wire_obj : top_module->wires_) {

--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -119,8 +119,7 @@ std::string Clock::WireName(RTLIL::Wire* wire) {
     if (!wire) {
 	return std::string();
     }
-    std::string wire_name(RTLIL::unescape_id(wire->name));
-    return std::regex_replace(wire_name, std::regex{"\\$"}, "\\$");
+    return AddEscaping(RTLIL::unescape_id(wire->name));
 }
 
 const std::map<std::string, RTLIL::Wire*> Clocks::GetClocks(RTLIL::Design* design) {

--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -19,32 +19,65 @@
 #include <cassert>
 #include <cmath>
 #include <regex>
-#include "kernel/log.h"
 #include "kernel/register.h"
 #include "propagation.h"
 
+void Clock::Add(const std::string& name, RTLIL::Wire* wire, float period,
+                float rising_edge, float falling_edge) {
+    wire->set_string_attribute(RTLIL::escape_id("CLOCK_SIGNAL"), "yes");
+    wire->set_string_attribute(RTLIL::escape_id("CLASS"), "clock");
+    wire->set_string_attribute(RTLIL::escape_id("NAME"), name);
+    wire->set_string_attribute(RTLIL::escape_id("SOURCE_PINS"),
+                               Clock::ClockWireName(wire));
+    wire->set_string_attribute(RTLIL::escape_id("PERIOD"),
+                               std::to_string(period));
+    std::string waveform(std::to_string(rising_edge) + " " +
+                         std::to_string(falling_edge));
+    wire->set_string_attribute(RTLIL::escape_id("WAVEFORM"), waveform);
+}
+
+void Clock::Add(const std::string& name, std::vector<RTLIL::Wire*> wires,
+                float period, float rising_edge, float falling_edge) {
+    std::for_each(wires.begin(), wires.end(), [&](RTLIL::Wire* wire) {
+	Add(name, wire, period, rising_edge, falling_edge);
+    });
+}
+
+void Clock::Add(RTLIL::Wire* wire, float period, float rising_edge,
+                float falling_edge) {
+    Add(Clock::ClockWireName(wire), wire, period, rising_edge, falling_edge);
+}
+
 float Clock::Period(RTLIL::Wire* clock_wire) {
     if (!clock_wire->has_attribute(RTLIL::escape_id("PERIOD"))) {
-	log_warning("Period has not been specified\n Default value 0 will be used\n");
+	log_warning(
+	    "Period has not been specified\n Default value 0 will be used\n");
 	return 0;
     }
-    return std::stof(clock_wire->get_string_attribute(RTLIL::escape_id("PERIOD")));
+    return std::stof(
+        clock_wire->get_string_attribute(RTLIL::escape_id("PERIOD")));
 }
 
 std::pair<float, float> Clock::Waveform(RTLIL::Wire* clock_wire) {
     if (!clock_wire->has_attribute(RTLIL::escape_id("WAVEFORM"))) {
 	float period(Period(clock_wire));
 	if (!period) {
-	    log_cmd_error("Neither PERIOD nor WAVEFORM has been specified for wire %s\n", ClockWireName(clock_wire).c_str());
-	    return std::make_pair(0,0);
+	    log_cmd_error(
+	        "Neither PERIOD nor WAVEFORM has been specified for wire %s\n",
+	        ClockWireName(clock_wire).c_str());
+	    return std::make_pair(0, 0);
 	}
 	float falling_edge = period / 2;
-	log_warning("Waveform has not been specified\n Default value {0 %f} will be used\n", falling_edge);
+	log_warning(
+	    "Waveform has not been specified\n Default value {0 %f} will be "
+	    "used\n",
+	    falling_edge);
 	return std::make_pair(0, falling_edge);
     }
     float rising_edge(0);
     float falling_edge(0);
-    std::string waveform(clock_wire->get_string_attribute(RTLIL::escape_id("WAVEFORM")));
+    std::string waveform(
+        clock_wire->get_string_attribute(RTLIL::escape_id("WAVEFORM")));
     std::sscanf(waveform.c_str(), "%f %f", &rising_edge, &falling_edge);
     return std::make_pair(rising_edge, falling_edge);
 }
@@ -65,115 +98,18 @@ std::string Clock::ClockWireName(RTLIL::Wire* wire) {
     return std::regex_replace(wire_name, std::regex{"\\$"}, "\\$");
 }
 
-void Clocks::AddClock(const std::string& name, std::vector<RTLIL::Wire*> wires,
-                      float period, float rising_edge, float falling_edge) {
-    std::for_each(wires.begin(), wires.end(), [&](RTLIL::Wire* wire) {
-	AddClock(name, wire, period, rising_edge, falling_edge);
-    });
-}
-
-void Clocks::AddClock(const std::string& name, RTLIL::Wire* wire, float period,
-                      float rising_edge, float falling_edge) {
-    wire->set_string_attribute(RTLIL::escape_id("CLOCK_SIGNAL"), "yes");
-    wire->set_string_attribute(RTLIL::escape_id("CLASS"), "clock");
-    wire->set_string_attribute(RTLIL::escape_id("NAME"), name);
-    wire->set_string_attribute(RTLIL::escape_id("SOURCE_PINS"), Clock::ClockWireName(wire));
-    wire->set_string_attribute(RTLIL::escape_id("PERIOD"), std::to_string(period));
-    std::string waveform(std::to_string(rising_edge) + " " + std::to_string(falling_edge));
-    wire->set_string_attribute(RTLIL::escape_id("WAVEFORM"), waveform);
-}
-
-void Clocks::AddClock(RTLIL::Wire* wire, float period,
-                      float rising_edge, float falling_edge) {
-    AddClock(Clock::ClockWireName(wire), wire, period, rising_edge, falling_edge);
-}
-
 const std::vector<RTLIL::Wire*> Clocks::GetClocks(RTLIL::Design* design) {
     std::vector<RTLIL::Wire*> clock_wires;
     RTLIL::Module* top_module = design->top_module();
     for (auto& wire_obj : top_module->wires_) {
 	auto& wire = wire_obj.second;
 	if (wire->has_attribute(RTLIL::escape_id("CLOCK_SIGNAL"))) {
-		if (wire->get_string_attribute(RTLIL::escape_id("CLOCK_SIGNAL")) == "yes") {
-			clock_wires.push_back(wire);
-		}
+	    if (wire->get_string_attribute(RTLIL::escape_id("CLOCK_SIGNAL")) ==
+	        "yes") {
+		clock_wires.push_back(wire);
+	    }
 	}
     }
     return clock_wires;
 }
 
-void Clocks::Propagate(RTLIL::Design* design, NaturalPropagation* pass) {
-#ifdef SDC_DEBUG
-    log("Start natural clock propagation\n");
-#endif
-    for (auto& clock_wire : Clocks::GetClocks(design)) {
-#ifdef SDC_DEBUG
-	log("Processing clock %s\n", RTLIL::id2cstr(clock_wire->name));
-#endif
-	auto aliases = pass->FindAliasWires(clock_wire);
-	AddClock(Clock::ClockWireName(clock_wire), aliases,
-	         Clock::Period(clock_wire), Clock::RisingEdge(clock_wire),
-	         Clock::FallingEdge(clock_wire));
-    }
-#ifdef SDC_DEBUG
-    log("Finish natural clock propagation\n\n");
-#endif
-}
-
-void Clocks::Propagate(RTLIL::Design* design, BufferPropagation* pass) {
-#ifdef SDC_DEBUG
-    log("Start buffer clock propagation\n");
-    log("IBUF pass\n");
-#endif
-    PropagateThroughBuffers(pass, design, IBuf());
-#ifdef SDC_DEBUG
-    log("BUFG pass\n");
-#endif
-    PropagateThroughBuffers(pass, design, Bufg());
-#ifdef SDC_DEBUG
-    log("Finish buffer clock propagation\n\n");
-#endif
-}
-
-void Clocks::Propagate(RTLIL::Design* design, ClockDividerPropagation* pass) {
-#ifdef SDC_DEBUG
-    log("Start clock divider clock propagation\n");
-#endif
-    PropagateThroughClockDividers(pass, design, Pll());
-    PropagateThroughBuffers(pass, design, Bufg());
-#ifdef SDC_DEBUG
-    log("Finish clock divider clock propagation\n\n");
-#endif
-}
-
-void Clocks::PropagateThroughBuffers(Propagation* pass, RTLIL::Design* design,
-                                    Buffer buffer) {
-    for (auto& clock_wire : Clocks::GetClocks(design)) {
-#ifdef SDC_DEBUG
-	log("Clock wire %s\n", Clock::ClockWireName(clock_wire).c_str());
-#endif
-	auto buf_wires = pass->FindSinkWiresForCellType(clock_wire, buffer.type,
-	                                                buffer.output);
-	int path_delay(0);
-	for (auto wire : buf_wires) {
-#ifdef SDC_DEBUG
-	    log("%s wire: %s\n", buffer.type.c_str(),
-	        RTLIL::id2cstr(wire->name));
-#endif
-	    path_delay += buffer.delay;
-	    AddClock(wire, Clock::Period(clock_wire),
-	             Clock::RisingEdge(clock_wire) + path_delay,
-	             Clock::FallingEdge(clock_wire) + path_delay);
-	}
-    }
-}
-
-void Clocks::PropagateThroughClockDividers(ClockDividerPropagation* pass, RTLIL::Design* design,
-                                    ClockDivider divider) {
-    for (auto& clock_wire : Clocks::GetClocks(design)) {
-#ifdef SDC_DEBUG
-	log("Processing clock %s\n", Clock::ClockWireName(clock_wire).c_str());
-#endif
-	pass->PropagateClocksForCellType(clock_wire, divider.type);
-    }
-}

--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -54,8 +54,13 @@ float Clock::Period(RTLIL::Wire* clock_wire) {
 	    "Period has not been specified\n Default value 0 will be used\n");
 	return 0;
     }
-    return std::stof(
-        clock_wire->get_string_attribute(RTLIL::escape_id("PERIOD")));
+    float period(0);
+    try {
+	period = std::stof(clock_wire->get_string_attribute(RTLIL::escape_id("PERIOD")));
+    } catch (const std::invalid_argument& e) {
+	log_cmd_error("Incorrect PERIOD format\n");
+    }
+    return period;
 }
 
 std::pair<float, float> Clock::Waveform(RTLIL::Wire* clock_wire) {
@@ -78,7 +83,9 @@ std::pair<float, float> Clock::Waveform(RTLIL::Wire* clock_wire) {
     float falling_edge(0);
     std::string waveform(
         clock_wire->get_string_attribute(RTLIL::escape_id("WAVEFORM")));
-    std::sscanf(waveform.c_str(), "%f %f", &rising_edge, &falling_edge);
+    if (std::sscanf(waveform.c_str(), "%f %f", &rising_edge, &falling_edge) != 2) {
+	log_cmd_error("Incorrect WAVEFORM format\n");
+    }
     return std::make_pair(rising_edge, falling_edge);
 }
 

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -40,8 +40,11 @@ class Clock {
     std::vector<RTLIL::Wire*> GetClockWires() { return clock_wires_; }
     const std::string& Name() const { return name_; }
     float Period() { return period_; }
+    static float Period(RTLIL::Wire* clock_wire);
     float RisingEdge() { return rising_edge_; }
+    static float RisingEdge(RTLIL::Wire* clock_wire);
     float FallingEdge() { return falling_edge_; }
+    static float FallingEdge(RTLIL::Wire* clock_wire);
     RTLIL::Wire* ClockWire() { return clock_wire_; }
     void UpdateClock(RTLIL::Wire* wire, float period, float rising_edge,
                      float falling_edge);
@@ -55,6 +58,7 @@ class Clock {
     float rising_edge_;
     float falling_edge_;
 
+    static std::pair<float, float> Waveform(RTLIL::Wire* clock_wire);
     void UpdateWires(RTLIL::Wire* wire);
     void UpdatePeriod(float period);
     void UpdateWaveform(float rising_edge, float falling_edge);

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -31,36 +31,13 @@ class Propagation;
 
 class Clock {
    public:
-    Clock(const std::string& name, RTLIL::Wire* wire, float period,
-          float rising_edge, float falling_edge);
-    Clock(const std::string& name, std::vector<RTLIL::Wire*> wires,
-          float period, float rising_edge, float falling_edge);
-    Clock(RTLIL::Wire* wire, float period,
-	    float rising_edge, float falling_edge);
-    std::vector<RTLIL::Wire*> GetClockWires() { return clock_wires_; }
-    const std::string& Name() const { return name_; }
     static float Period(RTLIL::Wire* clock_wire);
-    float RisingEdge() { return rising_edge_; }
     static float RisingEdge(RTLIL::Wire* clock_wire);
-    float FallingEdge() { return falling_edge_; }
     static float FallingEdge(RTLIL::Wire* clock_wire);
-    RTLIL::Wire* ClockWire() { return clock_wire_; }
-    void UpdateClock(RTLIL::Wire* wire, float period, float rising_edge,
-                     float falling_edge);
     static std::string ClockWireName(RTLIL::Wire* wire);
 
    private:
-    std::string name_;
-    std::vector<RTLIL::Wire*> clock_wires_;
-    RTLIL::Wire* clock_wire_;
-    float period_;
-    float rising_edge_;
-    float falling_edge_;
-
     static std::pair<float, float> Waveform(RTLIL::Wire* clock_wire);
-    void UpdateWires(RTLIL::Wire* wire);
-    void UpdatePeriod(float period);
-    void UpdateWaveform(float rising_edge, float falling_edge);
 };
 
 class Clocks {
@@ -79,6 +56,8 @@ class Clocks {
    private:
     void PropagateThroughBuffers(Propagation* pass, RTLIL::Design* design,
                                 Buffer buffer);
+    void PropagateThroughClockDividers(ClockDividerPropagation* pass, RTLIL::Design* design,
+                                ClockDivider divider);
 };
 
 #endif  // _CLOCKS_H_

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -18,6 +18,7 @@
 #ifndef _CLOCKS_H_
 #define _CLOCKS_H_
 
+#include <map>
 #include <vector>
 #include "buffers.h"
 #include "kernel/rtlil.h"
@@ -32,15 +33,16 @@ class Propagation;
 class Clock {
    public:
     static void Add(const std::string& name, RTLIL::Wire* wire, float period,
-                  float rising_edge, float falling_edge);
+                    float rising_edge, float falling_edge);
     static void Add(const std::string& name, std::vector<RTLIL::Wire*> wires,
-                  float period, float rising_edge, float falling_edge);
-    static void Add(RTLIL::Wire* wire, float period,
-                  float rising_edge, float falling_edge);
+                    float period, float rising_edge, float falling_edge);
+    static void Add(RTLIL::Wire* wire, float period, float rising_edge,
+                    float falling_edge);
     static float Period(RTLIL::Wire* clock_wire);
     static float RisingEdge(RTLIL::Wire* clock_wire);
     static float FallingEdge(RTLIL::Wire* clock_wire);
-    static std::string ClockWireName(RTLIL::Wire* wire);
+    static std::string Name(RTLIL::Wire* clock_wire);
+    static std::string WireName(RTLIL::Wire* wire);
 
    private:
     static std::pair<float, float> Waveform(RTLIL::Wire* clock_wire);
@@ -48,7 +50,7 @@ class Clock {
 
 class Clocks {
    public:
-    static const std::vector<RTLIL::Wire*> GetClocks(RTLIL::Design* design);
+    static const std::map<std::string, RTLIL::Wire*> GetClocks(RTLIL::Design* design);
 };
 
 #endif  // _CLOCKS_H_

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -39,7 +39,6 @@ class Clock {
 	    float rising_edge, float falling_edge);
     std::vector<RTLIL::Wire*> GetClockWires() { return clock_wires_; }
     const std::string& Name() const { return name_; }
-    float Period() { return period_; }
     static float Period(RTLIL::Wire* clock_wire);
     float RisingEdge() { return rising_edge_; }
     static float RisingEdge(RTLIL::Wire* clock_wire);
@@ -66,18 +65,19 @@ class Clock {
 
 class Clocks {
    public:
-    void AddClock(const std::string& name, std::vector<RTLIL::Wire*> wires,
+    static void AddClock(const std::string& name, std::vector<RTLIL::Wire*> wires,
                   float period, float rising_edge, float falling_edge);
-    void AddClock(const std::string& name, RTLIL::Wire* wire, float period,
+    static void AddClock(const std::string& name, RTLIL::Wire* wire, float period,
                   float rising_edge, float falling_edge);
-    void AddClock(Clock& clock);
+    static void AddClock(RTLIL::Wire* wire, float period,
+                  float rising_edge, float falling_edge);
+    static const std::vector<RTLIL::Wire*> GetClocks(RTLIL::Design* design);
     void Propagate(RTLIL::Design* design, NaturalPropagation* pass);
     void Propagate(RTLIL::Design* design, BufferPropagation* pass);
     void Propagate(RTLIL::Design* design, ClockDividerPropagation* pass);
-    static const std::vector<RTLIL::Wire*> GetClocks(RTLIL::Design* design);
 
    private:
-    void PropagateThroughBuffer(Propagation* pass, RTLIL::Design* design, Clock& clock,
+    void PropagateThroughBuffers(Propagation* pass, RTLIL::Design* design,
                                 Buffer buffer);
 };
 

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -42,6 +42,7 @@ class Clock {
     float Period() { return period_; }
     float RisingEdge() { return rising_edge_; }
     float FallingEdge() { return falling_edge_; }
+    RTLIL::Wire* ClockWire() { return clock_wire_; }
     void UpdateClock(RTLIL::Wire* wire, float period, float rising_edge,
                      float falling_edge);
     static std::string ClockWireName(RTLIL::Wire* wire);
@@ -49,6 +50,7 @@ class Clock {
    private:
     std::string name_;
     std::vector<RTLIL::Wire*> clock_wires_;
+    RTLIL::Wire* clock_wire_;
     float period_;
     float rising_edge_;
     float falling_edge_;
@@ -66,17 +68,17 @@ class Clocks {
                   float rising_edge, float falling_edge);
     void AddClock(Clock& clock);
     std::vector<std::string> GetClockNames();
-    void Propagate(NaturalPropagation* pass);
-    void Propagate(BufferPropagation* pass);
-    void Propagate(ClockDividerPropagation* pass);
-    void WriteSdc(std::ostream& file);
+    void Propagate(RTLIL::Design* design, NaturalPropagation* pass);
+    void Propagate(RTLIL::Design* design, BufferPropagation* pass);
+    void Propagate(RTLIL::Design* design, ClockDividerPropagation* pass);
     const std::vector<Clock> GetClocks() {
-	return clocks_;
+	return std::vector<Clock>();
     }
+    static const std::vector<RTLIL::Wire*> GetClocks(RTLIL::Design* design);
 
    private:
     std::vector<Clock> clocks_;
-    void PropagateThroughBuffer(Propagation* pass, Clock& clock,
+    void PropagateThroughBuffer(Propagation* pass, RTLIL::Design* design, Clock& clock,
                                 Buffer buffer);
 };
 

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -67,17 +67,12 @@ class Clocks {
     void AddClock(const std::string& name, RTLIL::Wire* wire, float period,
                   float rising_edge, float falling_edge);
     void AddClock(Clock& clock);
-    std::vector<std::string> GetClockNames();
     void Propagate(RTLIL::Design* design, NaturalPropagation* pass);
     void Propagate(RTLIL::Design* design, BufferPropagation* pass);
     void Propagate(RTLIL::Design* design, ClockDividerPropagation* pass);
-    const std::vector<Clock> GetClocks() {
-	return std::vector<Clock>();
-    }
     static const std::vector<RTLIL::Wire*> GetClocks(RTLIL::Design* design);
 
    private:
-    std::vector<Clock> clocks_;
     void PropagateThroughBuffer(Propagation* pass, RTLIL::Design* design, Clock& clock,
                                 Buffer buffer);
 };

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -31,6 +31,12 @@ class Propagation;
 
 class Clock {
    public:
+    static void Add(const std::string& name, RTLIL::Wire* wire, float period,
+                  float rising_edge, float falling_edge);
+    static void Add(const std::string& name, std::vector<RTLIL::Wire*> wires,
+                  float period, float rising_edge, float falling_edge);
+    static void Add(RTLIL::Wire* wire, float period,
+                  float rising_edge, float falling_edge);
     static float Period(RTLIL::Wire* clock_wire);
     static float RisingEdge(RTLIL::Wire* clock_wire);
     static float FallingEdge(RTLIL::Wire* clock_wire);
@@ -42,22 +48,7 @@ class Clock {
 
 class Clocks {
    public:
-    static void AddClock(const std::string& name, std::vector<RTLIL::Wire*> wires,
-                  float period, float rising_edge, float falling_edge);
-    static void AddClock(const std::string& name, RTLIL::Wire* wire, float period,
-                  float rising_edge, float falling_edge);
-    static void AddClock(RTLIL::Wire* wire, float period,
-                  float rising_edge, float falling_edge);
     static const std::vector<RTLIL::Wire*> GetClocks(RTLIL::Design* design);
-    void Propagate(RTLIL::Design* design, NaturalPropagation* pass);
-    void Propagate(RTLIL::Design* design, BufferPropagation* pass);
-    void Propagate(RTLIL::Design* design, ClockDividerPropagation* pass);
-
-   private:
-    void PropagateThroughBuffers(Propagation* pass, RTLIL::Design* design,
-                                Buffer buffer);
-    void PropagateThroughClockDividers(ClockDividerPropagation* pass, RTLIL::Design* design,
-                                ClockDivider divider);
 };
 
 #endif  // _CLOCKS_H_

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -43,6 +43,9 @@ class Clock {
     static float FallingEdge(RTLIL::Wire* clock_wire);
     static std::string Name(RTLIL::Wire* clock_wire);
     static std::string WireName(RTLIL::Wire* wire);
+    static std::string AddEscaping(const std::string& name) {
+	return std::regex_replace(name, std::regex{"\\$"}, "\\$");
+    }
 
    private:
     static std::pair<float, float> Waveform(RTLIL::Wire* clock_wire);

--- a/sdc-plugin/propagation.cc
+++ b/sdc-plugin/propagation.cc
@@ -40,29 +40,27 @@ std::vector<RTLIL::Wire*> NaturalPropagation::FindAliasWires(
 std::vector<Clock> ClockDividerPropagation::FindSinkClocksForCellType(
     Clock driving_clock, const std::string& cell_type) {
     std::vector<Clock> clocks;
-    auto clock_wires = driving_clock.GetClockWires();
-    for (auto clock_wire : clock_wires) {
-	if (cell_type == "PLLE2_ADV") {
-	    RTLIL::Cell* cell = NULL;
-	    for (auto input : Pll::inputs) {
-		cell = FindSinkCellOnPort(clock_wire, input);
-		if (cell and RTLIL::unescape_id(cell->type) == cell_type) {
-		    break;
-		}
+    auto clock_wire = driving_clock.ClockWire();
+    if (cell_type == "PLLE2_ADV") {
+	RTLIL::Cell* cell = NULL;
+	for (auto input : Pll::inputs) {
+	    cell = FindSinkCellOnPort(clock_wire, input);
+	    if (cell and RTLIL::unescape_id(cell->type) == cell_type) {
+		break;
 	    }
-	    if (!cell) {
-		return clocks;
-	    }
-	    Pll pll(cell, driving_clock.Period(), driving_clock.RisingEdge());
-	    for (auto output : Pll::outputs) {
-		RTLIL::Wire* wire = FindSinkWireOnPort(cell, output);
-		if (wire) {
-		    float clkout_period(pll.clkout_period.at(output));
-		    float clkout_rising_edge(pll.clkout_rising_edge.at(output));
-		    float clkout_falling_edge(pll.clkout_falling_edge.at(output));
-		    Clock clock(wire, clkout_period, clkout_rising_edge, clkout_falling_edge);
-		    clocks.push_back(clock);
-		}
+	}
+	if (!cell) {
+	    return clocks;
+	}
+	Pll pll(cell, driving_clock.Period(), driving_clock.RisingEdge());
+	for (auto output : Pll::outputs) {
+	    RTLIL::Wire* wire = FindSinkWireOnPort(cell, output);
+	    if (wire) {
+		float clkout_period(pll.clkout_period.at(output));
+		float clkout_rising_edge(pll.clkout_rising_edge.at(output));
+		float clkout_falling_edge(pll.clkout_falling_edge.at(output));
+		Clock clock(wire, clkout_period, clkout_rising_edge, clkout_falling_edge);
+		clocks.push_back(clock);
 	    }
 	}
     }

--- a/sdc-plugin/propagation.cc
+++ b/sdc-plugin/propagation.cc
@@ -21,9 +21,10 @@
 USING_YOSYS_NAMESPACE
 
 void Propagation::PropagateThroughBuffers(Buffer buffer) {
-    for (auto& clock_wire : Clocks::GetClocks(design_)) {
+    for (auto& clock : Clocks::GetClocks(design_)) {
+	auto& clock_wire = clock.second;
 #ifdef SDC_DEBUG
-	log("Clock wire %s\n", Clock::ClockWireName(clock_wire).c_str());
+	log("Clock wire %s\n", Clock::WireName(clock_wire).c_str());
 #endif
 	auto buf_wires =
 	    FindSinkWiresForCellType(clock_wire, buffer.type, buffer.output);
@@ -143,12 +144,13 @@ void NaturalPropagation::Run() {
 #ifdef SDC_DEBUG
     log("Start natural clock propagation\n");
 #endif
-    for (auto& clock_wire : Clocks::GetClocks(design_)) {
+    for (auto& clock : Clocks::GetClocks(design_)) {
+	auto& clock_wire = clock.second;
 #ifdef SDC_DEBUG
 	log("Processing clock %s\n", RTLIL::id2cstr(clock_wire->name));
 #endif
 	auto aliases = FindAliasWires(clock_wire);
-	Clock::Add(Clock::ClockWireName(clock_wire), aliases,
+	Clock::Add(Clock::WireName(clock_wire), aliases,
 	           Clock::Period(clock_wire), Clock::RisingEdge(clock_wire),
 	           Clock::FallingEdge(clock_wire));
     }
@@ -202,9 +204,10 @@ void ClockDividerPropagation::Run() {
 
 void ClockDividerPropagation::PropagateThroughClockDividers(
     ClockDivider divider) {
-    for (auto& clock_wire : Clocks::GetClocks(design_)) {
+    for (auto& clock : Clocks::GetClocks(design_)) {
+	auto& clock_wire = clock.second;
 #ifdef SDC_DEBUG
-	log("Processing clock %s\n", Clock::ClockWireName(clock_wire).c_str());
+	log("Processing clock %s\n", Clock::WireName(clock_wire).c_str());
 #endif
 	PropagateClocksForCellType(clock_wire, divider.type);
     }

--- a/sdc-plugin/propagation.h
+++ b/sdc-plugin/propagation.h
@@ -26,17 +26,18 @@ class Propagation {
    public:
     Propagation(RTLIL::Design* design, Pass* pass)
         : design_(design), pass_(pass) {}
-    virtual ~Propagation(){}
+    virtual ~Propagation() {}
 
-    virtual void Run(Clocks& clocks) = 0;
-    std::vector<RTLIL::Wire*> FindSinkWiresForCellType(
-        RTLIL::Wire* driver_wire, const std::string& cell_type,
-        const std::string& cell_port);
+    virtual void Run() = 0;
 
    protected:
     RTLIL::Design* design_;
     Pass* pass_;
 
+    void PropagateThroughBuffers(Buffer buffer);
+    std::vector<RTLIL::Wire*> FindSinkWiresForCellType(
+        RTLIL::Wire* driver_wire, const std::string& cell_type,
+        const std::string& cell_port);
     RTLIL::Cell* FindSinkCellOfType(RTLIL::Wire* wire, const std::string& type);
     RTLIL::Cell* FindSinkCellOnPort(RTLIL::Wire* wire, const std::string& port);
     RTLIL::Wire* FindSinkWireOnPort(RTLIL::Cell* cell,
@@ -48,7 +49,7 @@ class NaturalPropagation : public Propagation {
     NaturalPropagation(RTLIL::Design* design, Pass* pass)
         : Propagation(design, pass) {}
 
-    void Run(Clocks& clocks) override { clocks.Propagate(design_, this); }
+    void Run() override;
     std::vector<RTLIL::Wire*> FindAliasWires(RTLIL::Wire* wire);
 };
 
@@ -57,7 +58,7 @@ class BufferPropagation : public Propagation {
     BufferPropagation(RTLIL::Design* design, Pass* pass)
         : Propagation(design, pass) {}
 
-    void Run(Clocks& clocks) override { clocks.Propagate(design_, this); }
+    void Run() override;
 };
 
 class ClockDividerPropagation : public Propagation {
@@ -65,8 +66,9 @@ class ClockDividerPropagation : public Propagation {
     ClockDividerPropagation(RTLIL::Design* design, Pass* pass)
         : Propagation(design, pass) {}
 
-    void Run(Clocks& clocks) override { clocks.Propagate(design_, this); }
+    void Run() override;
     void PropagateClocksForCellType(RTLIL::Wire* driver_wire,
-                                                 const std::string& cell_type);
+                                    const std::string& cell_type);
+    void PropagateThroughClockDividers(ClockDivider divider);
 };
 #endif  // PROPAGATION_H_

--- a/sdc-plugin/propagation.h
+++ b/sdc-plugin/propagation.h
@@ -48,7 +48,7 @@ class NaturalPropagation : public Propagation {
     NaturalPropagation(RTLIL::Design* design, Pass* pass)
         : Propagation(design, pass) {}
 
-    void Run(Clocks& clocks) override { clocks.Propagate(this); }
+    void Run(Clocks& clocks) override { clocks.Propagate(design_, this); }
     std::vector<RTLIL::Wire*> FindAliasWires(RTLIL::Wire* wire);
 };
 
@@ -57,7 +57,7 @@ class BufferPropagation : public Propagation {
     BufferPropagation(RTLIL::Design* design, Pass* pass)
         : Propagation(design, pass) {}
 
-    void Run(Clocks& clocks) override { clocks.Propagate(this); }
+    void Run(Clocks& clocks) override { clocks.Propagate(design_, this); }
 };
 
 class ClockDividerPropagation : public Propagation {
@@ -65,7 +65,7 @@ class ClockDividerPropagation : public Propagation {
     ClockDividerPropagation(RTLIL::Design* design, Pass* pass)
         : Propagation(design, pass) {}
 
-    void Run(Clocks& clocks) override { clocks.Propagate(this); }
+    void Run(Clocks& clocks) override { clocks.Propagate(design_, this); }
     std::vector<Clock> FindSinkClocksForCellType(Clock driver_wire,
                                                  const std::string& cell_type);
 };

--- a/sdc-plugin/propagation.h
+++ b/sdc-plugin/propagation.h
@@ -66,7 +66,7 @@ class ClockDividerPropagation : public Propagation {
         : Propagation(design, pass) {}
 
     void Run(Clocks& clocks) override { clocks.Propagate(design_, this); }
-    std::vector<Clock> FindSinkClocksForCellType(Clock driver_wire,
+    void PropagateClocksForCellType(RTLIL::Wire* driver_wire,
                                                  const std::string& cell_type);
 };
 #endif  // PROPAGATION_H_

--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -235,9 +235,9 @@ struct PropagateClocksCmd : public Pass {
 	}
 
 	std::array<std::unique_ptr<Propagation>, 2> passes{
-	    std::unique_ptr<BufferPropagation>(
+	    std::unique_ptr<Propagation>(
 	        new BufferPropagation(design, this)),
-	    std::unique_ptr<ClockDividerPropagation>(
+	    std::unique_ptr<Propagation>(
 	        new ClockDividerPropagation(design, this))};
 
 	log("Perform clock propagation\n");

--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -73,13 +73,13 @@ struct WriteSdcCmd : public Backend {
     }
 
     void execute(std::ostream*& f, std::string filename,
-                 std::vector<std::string> args, RTLIL::Design*) override {
+                 std::vector<std::string> args, RTLIL::Design* design) override {
 	if (args.size() < 2) {
 	    log_cmd_error("Missing output file.\n");
 	}
 	log("\nWriting out clock constraints file(SDC)\n");
 	extra_args(f, filename, args, 1);
-	sdc_writer_.WriteSdc(clocks_, *f);
+	sdc_writer_.WriteSdc(design, *f);
     }
 
     Clocks& clocks_;

--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -197,13 +197,14 @@ struct GetClocksCmd : public Pass {
 	if (args.size() > 1) {
 	    log_warning("Command doesn't support arguments, so they will be ignored.\n");
 	}
-	std::vector<RTLIL::Wire*> clock_wires(Clocks::GetClocks(design));
-	if (clock_wires.size() == 0) {
+	std::map<std::string, RTLIL::Wire*> clocks(Clocks::GetClocks(design));
+	if (clocks.size() == 0) {
 	    log_warning("No clocks found in design\n");
 	}
 	Tcl_Interp* interp = yosys_get_tcl_interp();
 	Tcl_Obj* tcl_list = Tcl_NewListObj(0, NULL);
-	for (auto wire : clock_wires) {
+	for (auto& clock : clocks) {
+	    auto& wire = clock.second;
 	    const char* name = RTLIL::id2cstr(wire->name);
 	    Tcl_Obj* name_obj = Tcl_NewStringObj(name, -1);
 	    Tcl_ListObjAppendElement(interp, tcl_list, name_obj);

--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -37,11 +37,25 @@ void SdcWriter::AddClockGroup(ClockGroups::ClockGroup clock_group, ClockGroups::
     clock_groups_.Add(clock_group, relation);
 }
 
-void SdcWriter::WriteSdc(Clocks& clocks, std::ostream& file) {
-    WriteClocks(clocks, file);
+void SdcWriter::WriteSdc(RTLIL::Design* design, std::ostream& file) {
+    WriteClocks(design, file);
     WriteFalsePaths(file);
     WriteMaxDelay(file);
     WriteClockGroups(file);
+}
+
+void SdcWriter::WriteClocks(RTLIL::Design* design, std::ostream& file) {
+    for (auto& clock_wire : Clocks::GetClocks(design)) {
+	// FIXME: Input port nets are not found in VPR
+	if (clock_wire->port_input) {
+	    continue;
+	}
+	file << "create_clock -period " << clock_wire->get_string_attribute(RTLIL::escape_id("PERIOD"));
+	/* file << " -waveform {" << clock.RisingEdge() << " " */
+	/*      << clock.FallingEdge() << "}"; */
+	file << " " << RTLIL::unescape_id(clock_wire->name);
+	file << std::endl;
+    }
 }
 
 void SdcWriter::WriteClocks(Clocks& clocks, std::ostream& file) {

--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -50,10 +50,10 @@ void SdcWriter::WriteClocks(RTLIL::Design* design, std::ostream& file) {
 	if (clock_wire->port_input) {
 	    continue;
 	}
-	file << "create_clock -period " << clock_wire->get_string_attribute(RTLIL::escape_id("PERIOD"));
-	/* file << " -waveform {" << clock.RisingEdge() << " " */
-	/*      << clock.FallingEdge() << "}"; */
-	file << " " << RTLIL::unescape_id(clock_wire->name);
+	file << "create_clock -period " << Clock::Period(clock_wire);
+	file << " -waveform {" << Clock::RisingEdge(clock_wire) << " "
+	     << Clock::FallingEdge(clock_wire) << "}";
+	file << " " << Clock::ClockWireName(clock_wire);
 	file << std::endl;
     }
 }

--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -45,15 +45,16 @@ void SdcWriter::WriteSdc(RTLIL::Design* design, std::ostream& file) {
 }
 
 void SdcWriter::WriteClocks(RTLIL::Design* design, std::ostream& file) {
-    for (auto& clock_wire : Clocks::GetClocks(design)) {
+    for (auto& clock : Clocks::GetClocks(design)) {
 	// FIXME: Input port nets are not found in VPR
+	auto& clock_wire = clock.second;
 	if (clock_wire->port_input) {
 	    continue;
 	}
 	file << "create_clock -period " << Clock::Period(clock_wire);
 	file << " -waveform {" << Clock::RisingEdge(clock_wire) << " "
 	     << Clock::FallingEdge(clock_wire) << "}";
-	file << " " << Clock::ClockWireName(clock_wire);
+	file << " " << Clock::WireName(clock_wire);
 	file << std::endl;
     }
 }

--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -58,27 +58,6 @@ void SdcWriter::WriteClocks(RTLIL::Design* design, std::ostream& file) {
     }
 }
 
-void SdcWriter::WriteClocks(Clocks& clocks, std::ostream& file) {
-    for (auto clock : clocks.GetClocks()) {
-	auto clock_wires = clock.GetClockWires();
-	// FIXME: Input port nets are not found in VPR
-	if (std::all_of(clock_wires.begin(), clock_wires.end(),
-	                [&](RTLIL::Wire* wire) { return wire->port_input; })) {
-	    continue;
-	}
-	file << "create_clock -period " << clock.Period();
-	file << " -waveform {" << clock.RisingEdge() << " "
-	     << clock.FallingEdge() << "}";
-	for (auto clock_wire : clock_wires) {
-	    if (clock_wire->port_input) {
-		continue;
-	    }
-	    file << " " << Clock::ClockWireName(clock_wire);
-	}
-	file << std::endl;
-    }
-}
-
 void SdcWriter::WriteFalsePaths(std::ostream& file) {
     for (auto path : false_paths_) {
 	file << "set_false_path";

--- a/sdc-plugin/sdc_writer.h
+++ b/sdc-plugin/sdc_writer.h
@@ -64,7 +64,6 @@ class SdcWriter {
     void WriteSdc(RTLIL::Design* design, std::ostream& file);
 
    private:
-    void WriteClocks(Clocks& clocks, std::ostream& file);
     void WriteClocks(RTLIL::Design* design, std::ostream& file);
     void WriteFalsePaths(std::ostream& file);
     void WriteMaxDelay(std::ostream& file);

--- a/sdc-plugin/sdc_writer.h
+++ b/sdc-plugin/sdc_writer.h
@@ -61,10 +61,11 @@ class SdcWriter {
     void AddFalsePath(FalsePath false_path);
     void SetMaxDelay(TimingPath timing_path);
     void AddClockGroup(ClockGroups::ClockGroup clock_group, ClockGroups::ClockGroupRelation relation);
-    void WriteSdc(Clocks& clocks, std::ostream& file);
+    void WriteSdc(RTLIL::Design* design, std::ostream& file);
 
    private:
     void WriteClocks(Clocks& clocks, std::ostream& file);
+    void WriteClocks(RTLIL::Design* design, std::ostream& file);
     void WriteFalsePaths(std::ostream& file);
     void WriteMaxDelay(std::ostream& file);
     void WriteClockGroups(std::ostream& file);

--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -11,7 +11,8 @@ TESTS = counter \
 	pll_approx_equal \
 	set_false_path \
 	set_max_delay \
-	set_clock_groups
+	set_clock_groups \
+	restore_from_json
 
 include $(shell pwd)/../../Makefile_test.common
 
@@ -24,3 +25,4 @@ pll_approx_equal_verify = $(call diff_test,pll_approx_equal,sdc)
 set_false_path_verify = $(call diff_test,set_false_path,sdc)
 set_max_delay_verify = $(call diff_test,set_max_delay,sdc)
 set_clock_groups_verify = $(call diff_test,set_clock_groups,sdc)
+restore_from_json_verify = diff restore_from_json/restore_from_json_1.sdc restore_from_json/restore_from_json_2.sdc

--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -16,6 +16,8 @@ TESTS = counter \
 	period_check \
 	waveform_check
 
+UNIT_TESTS = escaping
+
 include $(shell pwd)/../../Makefile_test.common
 
 counter_verify = $(call diff_test,counter,sdc) && $(call diff_test,counter,txt)

--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -2,6 +2,10 @@
 # set_false_path - test the set_false_path command
 # set_max_delay - test the set_max_delay command
 # set_clock_groups - test the set_clock_groups command
+# restore_from_json - test clock propagation when design restored from json instead verilog
+# period_check - test if the clock propagation fails if a clock wire is missing the PERIOD attribute
+# waveform_check - test if the WAVEFORM attribute value is correct on wire
+# period_format_check - test if PERIOD attribute value is correct on wire
 
 TESTS = counter \
 	counter2 \
@@ -14,7 +18,8 @@ TESTS = counter \
 	set_clock_groups \
 	restore_from_json \
 	period_check \
-	waveform_check
+	waveform_check \
+	period_format_check
 
 UNIT_TESTS = escaping
 
@@ -34,3 +39,5 @@ period_check_verify = true
 period_check_negative = 1
 waveform_check_verify = true
 waveform_check_negative = 1
+period_format_check_verify = true
+period_format_check_negative = 1

--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -12,7 +12,9 @@ TESTS = counter \
 	set_false_path \
 	set_max_delay \
 	set_clock_groups \
-	restore_from_json
+	restore_from_json \
+	period_check \
+	waveform_check
 
 include $(shell pwd)/../../Makefile_test.common
 
@@ -26,3 +28,7 @@ set_false_path_verify = $(call diff_test,set_false_path,sdc)
 set_max_delay_verify = $(call diff_test,set_max_delay,sdc)
 set_clock_groups_verify = $(call diff_test,set_clock_groups,sdc)
 restore_from_json_verify = diff restore_from_json/restore_from_json_1.sdc restore_from_json/restore_from_json_2.sdc
+period_check_verify = true
+period_check_negative = 1
+waveform_check_verify = true
+waveform_check_negative = 1

--- a/sdc-plugin/tests/counter/counter.golden.sdc
+++ b/sdc-plugin/tests/counter/counter.golden.sdc
@@ -1,6 +1,6 @@
-create_clock -period 10 -waveform {0 5} clk_int_1
-create_clock -period 10 -waveform {0 5} ibuf_proxy_out
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1918
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1920
+create_clock -period 10 -waveform {0 5} clk_int_1
+create_clock -period 10 -waveform {0 5} ibuf_proxy_out
 create_clock -period 10 -waveform {0 5} middle_inst_1.clk_int
 create_clock -period 10 -waveform {0 5} middle_inst_4.clk

--- a/sdc-plugin/tests/counter/counter.golden.txt
+++ b/sdc-plugin/tests/counter/counter.golden.txt
@@ -1,1 +1,1 @@
-clk_int_1 clk ibuf_proxy_out {$auto$clkbufmap.cc:247:execute$1918} {$auto$clkbufmap.cc:247:execute$1920} middle_inst_1.clk_int middle_inst_4.clk
+{$auto$clkbufmap.cc:247:execute$1918} {$auto$clkbufmap.cc:247:execute$1920} clk clk2 clk_int_1 ibuf_proxy_out middle_inst_1.clk_int middle_inst_4.clk

--- a/sdc-plugin/tests/counter/counter.tcl
+++ b/sdc-plugin/tests/counter/counter.tcl
@@ -24,3 +24,4 @@ close $fh
 
 # Write out the SDC file after the clock propagation step
 write_sdc $::env(DESIGN_TOP).sdc
+write_json $::env(DESIGN_TOP).json

--- a/sdc-plugin/tests/counter2/counter2.golden.sdc
+++ b/sdc-plugin/tests/counter2/counter2.golden.sdc
@@ -1,6 +1,6 @@
-create_clock -period 10 -waveform {0 5} clk_int_1
-create_clock -period 10 -waveform {0 5} ibuf_proxy_out
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1918
 create_clock -period 10 -waveform {1 6} \$auto\$clkbufmap.cc:247:execute\$1920
+create_clock -period 10 -waveform {0 5} clk_int_1
+create_clock -period 10 -waveform {0 5} ibuf_proxy_out
 create_clock -period 10 -waveform {0 5} middle_inst_1.clk_int
 create_clock -period 10 -waveform {1 6} middle_inst_4.clk

--- a/sdc-plugin/tests/counter2/counter2.golden.txt
+++ b/sdc-plugin/tests/counter2/counter2.golden.txt
@@ -1,1 +1,1 @@
-clk_int_1 clk clk2 ibuf_proxy_out {$auto$clkbufmap.cc:247:execute$1918} {$auto$clkbufmap.cc:247:execute$1920} middle_inst_1.clk_int middle_inst_4.clk
+{$auto$clkbufmap.cc:247:execute$1918} {$auto$clkbufmap.cc:247:execute$1920} clk clk2 clk_int_1 ibuf_proxy_out middle_inst_1.clk_int middle_inst_4.clk

--- a/sdc-plugin/tests/escaping/escaping.test.cc
+++ b/sdc-plugin/tests/escaping/escaping.test.cc
@@ -1,0 +1,11 @@
+#include <clocks.h>
+
+#include <gtest/gtest.h>
+
+TEST(ClockTest, EscapeDollarSign) {
+        // convert wire_name to wire_name, i.e. unchanged
+        EXPECT_EQ(Clock::AddEscaping("wire_name"), "wire_name");
+        // convert $wire_name to \$wire_name
+        EXPECT_EQ(Clock::AddEscaping("$wire_name"), "\\$wire_name");
+}
+

--- a/sdc-plugin/tests/period_check/period_check.tcl
+++ b/sdc-plugin/tests/period_check/period_check.tcl
@@ -1,0 +1,17 @@
+yosys -import
+plugin -i sdc
+# Import the commands from the plugins to the tcl interpreter
+yosys -import
+
+read_verilog $::env(DESIGN_TOP).v
+read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+hierarchy -check -auto-top
+# Start flow after library reading
+synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+
+# Propagate the clocks
+propagate_clocks
+
+# Write out the SDC file after the clock propagation step
+write_sdc $::env(DESIGN_TOP).sdc

--- a/sdc-plugin/tests/period_check/period_check.v
+++ b/sdc-plugin/tests/period_check/period_check.v
@@ -1,4 +1,4 @@
-module top((* CLOCK_SIGNAL = "yes", PERIOD = "bad_value", WAVEFORM = "0 5" *) input clk,
+module top((* CLOCK_SIGNAL = "yes", WAVEFORM = "0 5" *) input clk,
         input clk2,
 	input [1:0] in,
 	output [5:0] out );

--- a/sdc-plugin/tests/period_check/period_check.v
+++ b/sdc-plugin/tests/period_check/period_check.v
@@ -1,0 +1,36 @@
+module top((* CLOCK_SIGNAL = "yes", PERIOD = "bad_value", WAVEFORM = "0 5" *) input clk,
+        input clk2,
+	input [1:0] in,
+	output [5:0] out );
+
+reg [1:0] cnt = 0;
+wire clk_int_1, clk_int_2;
+IBUF ibuf_proxy(.I(clk), .O(ibuf_proxy_out));
+IBUF ibuf_inst(.I(ibuf_proxy_out), .O(ibuf_out));
+assign clk_int_1 = ibuf_out;
+assign clk_int_2 = clk_int_1;
+
+always @(posedge clk_int_2) begin
+	cnt <= cnt + 1;
+end
+
+middle middle_inst_1(.clk(ibuf_out), .out(out[2]));
+middle middle_inst_2(.clk(clk_int_1), .out(out[3]));
+middle middle_inst_3(.clk(clk_int_2), .out(out[4]));
+middle middle_inst_4(.clk(clk2), .out(out[5]));
+
+assign out[1:0] = {cnt[0], in[0]};
+endmodule
+
+module middle(input clk,
+	output out);
+
+reg [1:0] cnt = 0;
+wire clk_int;
+assign clk_int = clk;
+always @(posedge clk_int) begin
+	cnt <= cnt + 1;
+end
+
+assign out = cnt[0];
+endmodule

--- a/sdc-plugin/tests/period_format_check/period_format_check.tcl
+++ b/sdc-plugin/tests/period_format_check/period_format_check.tcl
@@ -1,0 +1,17 @@
+yosys -import
+plugin -i sdc
+# Import the commands from the plugins to the tcl interpreter
+yosys -import
+
+read_verilog $::env(DESIGN_TOP).v
+read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+hierarchy -check -auto-top
+# Start flow after library reading
+synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+
+# Propagate the clocks
+propagate_clocks
+
+# Write out the SDC file after the clock propagation step
+write_sdc $::env(DESIGN_TOP).sdc

--- a/sdc-plugin/tests/period_format_check/period_format_check.v
+++ b/sdc-plugin/tests/period_format_check/period_format_check.v
@@ -1,0 +1,36 @@
+module top((* CLOCK_SIGNAL = "yes", PERIOD = "bad value", WAVEFORM = "0 5" *) input clk,
+        input clk2,
+	input [1:0] in,
+	output [5:0] out );
+
+reg [1:0] cnt = 0;
+wire clk_int_1, clk_int_2;
+IBUF ibuf_proxy(.I(clk), .O(ibuf_proxy_out));
+IBUF ibuf_inst(.I(ibuf_proxy_out), .O(ibuf_out));
+assign clk_int_1 = ibuf_out;
+assign clk_int_2 = clk_int_1;
+
+always @(posedge clk_int_2) begin
+	cnt <= cnt + 1;
+end
+
+middle middle_inst_1(.clk(ibuf_out), .out(out[2]));
+middle middle_inst_2(.clk(clk_int_1), .out(out[3]));
+middle middle_inst_3(.clk(clk_int_2), .out(out[4]));
+middle middle_inst_4(.clk(clk2), .out(out[5]));
+
+assign out[1:0] = {cnt[0], in[0]};
+endmodule
+
+module middle(input clk,
+	output out);
+
+reg [1:0] cnt = 0;
+wire clk_int;
+assign clk_int = clk;
+always @(posedge clk_int) begin
+	cnt <= cnt + 1;
+end
+
+assign out = cnt[0];
+endmodule

--- a/sdc-plugin/tests/pll/pll.golden.sdc
+++ b/sdc-plugin/tests/pll/pll.golden.sdc
@@ -1,8 +1,8 @@
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1829
-create_clock -period 10 -waveform {0 5} \$techmap1716\FDCE_0.C
 create_clock -period 10 -waveform {2.5 7.5} \$auto\$clkbufmap.cc:247:execute\$1831
-create_clock -period 10 -waveform {2.5 7.5} main_clkout0
 create_clock -period 2.5 -waveform {0 1.25} \$auto\$clkbufmap.cc:247:execute\$1833
-create_clock -period 2.5 -waveform {0 1.25} main_clkout1
 create_clock -period 5 -waveform {1.25 3.75} \$auto\$clkbufmap.cc:247:execute\$1835
+create_clock -period 10 -waveform {0 5} \$techmap1716\FDCE_0.C
+create_clock -period 10 -waveform {2.5 7.5} main_clkout0
+create_clock -period 2.5 -waveform {0 1.25} main_clkout1
 create_clock -period 5 -waveform {1.25 3.75} main_clkout2

--- a/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.golden.sdc
+++ b/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.golden.sdc
@@ -1,8 +1,8 @@
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1829
-create_clock -period 10 -waveform {0 5} \$techmap1716\FDCE_0.C
 create_clock -period 9.99999 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1831
-create_clock -period 9.99999 -waveform {0 5} main_clkout_x1
 create_clock -period 5 -waveform {-2.5 0} \$auto\$clkbufmap.cc:247:execute\$1833
-create_clock -period 5 -waveform {-2.5 0} main_clkout_x2
 create_clock -period 2.5 -waveform {-1.875 -0.624999} \$auto\$clkbufmap.cc:247:execute\$1835
+create_clock -period 10 -waveform {0 5} \$techmap1716\FDCE_0.C
+create_clock -period 9.99999 -waveform {0 5} main_clkout_x1
+create_clock -period 5 -waveform {-2.5 0} main_clkout_x2
 create_clock -period 2.5 -waveform {-1.875 -0.624999} main_clkout_x4

--- a/sdc-plugin/tests/pll_div/pll_div.golden.sdc
+++ b/sdc-plugin/tests/pll_div/pll_div.golden.sdc
@@ -1,8 +1,8 @@
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1829
-create_clock -period 10 -waveform {0 5} \$techmap1716\FDCE_0.C
 create_clock -period 20 -waveform {5 15} \$auto\$clkbufmap.cc:247:execute\$1831
-create_clock -period 20 -waveform {5 15} main_clkout0
 create_clock -period 5 -waveform {0 2.5} \$auto\$clkbufmap.cc:247:execute\$1833
-create_clock -period 5 -waveform {0 2.5} main_clkout1
 create_clock -period 10 -waveform {2.5 7.5} \$auto\$clkbufmap.cc:247:execute\$1835
+create_clock -period 10 -waveform {0 5} \$techmap1716\FDCE_0.C
+create_clock -period 20 -waveform {5 15} main_clkout0
+create_clock -period 5 -waveform {0 2.5} main_clkout1
 create_clock -period 10 -waveform {2.5 7.5} main_clkout2

--- a/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.golden.sdc
+++ b/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.golden.sdc
@@ -1,8 +1,8 @@
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1829
-create_clock -period 10 -waveform {0 5} \$techmap1716\FDCE_0.C
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:247:execute\$1831
-create_clock -period 10 -waveform {0 5} main_clkout_x1
 create_clock -period 5 -waveform {-2.5 0} \$auto\$clkbufmap.cc:247:execute\$1833
-create_clock -period 5 -waveform {-2.5 0} main_clkout_x2
 create_clock -period 2.5 -waveform {-1.875 -0.625} \$auto\$clkbufmap.cc:247:execute\$1835
+create_clock -period 10 -waveform {0 5} \$techmap1716\FDCE_0.C
+create_clock -period 10 -waveform {0 5} main_clkout_x1
+create_clock -period 5 -waveform {-2.5 0} main_clkout_x2
 create_clock -period 2.5 -waveform {-1.875 -0.625} main_clkout_x4

--- a/sdc-plugin/tests/restore_from_json/restore_from_json.tcl
+++ b/sdc-plugin/tests/restore_from_json/restore_from_json.tcl
@@ -1,0 +1,16 @@
+yosys -import
+
+plugin -i sdc
+
+yosys -import
+
+read_verilog $::env(DESIGN_TOP).v
+synth_xilinx
+create_clock -period 10 clk
+propagate_clocks
+write_sdc $::env(DESIGN_TOP)_1.sdc
+write_json $::env(DESIGN_TOP).json
+
+design -push
+read_json $::env(DESIGN_TOP).json
+write_sdc $::env(DESIGN_TOP)_2.sdc

--- a/sdc-plugin/tests/restore_from_json/restore_from_json.v
+++ b/sdc-plugin/tests/restore_from_json/restore_from_json.v
@@ -1,0 +1,11 @@
+module top(input clk, input i, output o);
+
+reg [0:0] outff = 0;
+
+assign o = outff;
+
+always @(posedge clk) begin
+    outff <= i;
+end
+
+endmodule

--- a/sdc-plugin/tests/waveform_check/waveform_check.tcl
+++ b/sdc-plugin/tests/waveform_check/waveform_check.tcl
@@ -1,0 +1,17 @@
+yosys -import
+plugin -i sdc
+# Import the commands from the plugins to the tcl interpreter
+yosys -import
+
+read_verilog $::env(DESIGN_TOP).v
+read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+hierarchy -check -auto-top
+# Start flow after library reading
+synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+
+# Propagate the clocks
+propagate_clocks
+
+# Write out the SDC file after the clock propagation step
+write_sdc $::env(DESIGN_TOP).sdc

--- a/sdc-plugin/tests/waveform_check/waveform_check.v
+++ b/sdc-plugin/tests/waveform_check/waveform_check.v
@@ -1,0 +1,36 @@
+module top((* CLOCK_SIGNAL = "yes", PERIOD = "10", WAVEFORM = "bad value" *) input clk,
+        input clk2,
+	input [1:0] in,
+	output [5:0] out );
+
+reg [1:0] cnt = 0;
+wire clk_int_1, clk_int_2;
+IBUF ibuf_proxy(.I(clk), .O(ibuf_proxy_out));
+IBUF ibuf_inst(.I(ibuf_proxy_out), .O(ibuf_out));
+assign clk_int_1 = ibuf_out;
+assign clk_int_2 = clk_int_1;
+
+always @(posedge clk_int_2) begin
+	cnt <= cnt + 1;
+end
+
+middle middle_inst_1(.clk(ibuf_out), .out(out[2]));
+middle middle_inst_2(.clk(clk_int_1), .out(out[3]));
+middle middle_inst_3(.clk(clk_int_2), .out(out[4]));
+middle middle_inst_4(.clk(clk2), .out(out[5]));
+
+assign out[1:0] = {cnt[0], in[0]};
+endmodule
+
+module middle(input clk,
+	output out);
+
+reg [1:0] cnt = 0;
+wire clk_int;
+assign clk_int = clk;
+always @(posedge clk_int) begin
+	cnt <= cnt + 1;
+end
+
+assign out = cnt[0];
+endmodule


### PR DESCRIPTION
This PR fixes #45 by modifying the current SDC plugin implementation to not keep the clock and generated clock information in a separate structure, but in Yosys' internal design representation. For this purpose the clock related attributes from [this list](https://docs.google.com/spreadsheets/d/1G-E2Dq8YG4g9Z6mTygpumwlI_vNlFUQinc9gMgePfec/edit#gid=1349094793) on the specified wires are set or updated using `create_clocks` or as a result of clock propagation.