### PR TITLE
Add -of switch and -include_generated_clocks to get_clocks command

### DIFF
--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -19,7 +19,8 @@ TESTS = counter \
 	restore_from_json \
 	period_check \
 	waveform_check \
-	period_format_check
+	period_format_check \
+	get_clocks
 
 UNIT_TESTS = escaping
 
@@ -41,3 +42,4 @@ waveform_check_verify = true
 waveform_check_negative = 1
 period_format_check_verify = true
 period_format_check_negative = 1
+get_clocks_verify = $(call diff_test,get_clocks,txt)

--- a/sdc-plugin/tests/get_clocks/get_clocks.golden.txt
+++ b/sdc-plugin/tests/get_clocks/get_clocks.golden.txt
@@ -1,0 +1,6 @@
+{$auto$clkbufmap.cc:247:execute$1913} {$auto$clkbufmap.cc:247:execute$1915} clk clk2 clk_int_1 middle_inst_1.clk_int middle_inst_4.clk
+{$auto$clkbufmap.cc:247:execute$1913} {$auto$clkbufmap.cc:247:execute$1915} clk clk2 clk_int_1 middle_inst_1.clk_int middle_inst_4.clk
+clk2
+clk_int_1
+clk clk2 clk_int_1 middle_inst_1.clk_int middle_inst_4.clk
+clk clk2 clk_int_1

--- a/sdc-plugin/tests/get_clocks/get_clocks.input.sdc
+++ b/sdc-plugin/tests/get_clocks/get_clocks.input.sdc
@@ -1,0 +1,2 @@
+create_clock -period 10.0 -waveform {0.000 5.000} clk_int_1
+create_clock -period 10.0 -name clk -waveform {0.000 5.000} clk clk2

--- a/sdc-plugin/tests/get_clocks/get_clocks.tcl
+++ b/sdc-plugin/tests/get_clocks/get_clocks.tcl
@@ -1,0 +1,35 @@
+yosys -import
+plugin -i sdc
+plugin -i design_introspection
+# Import the commands from the plugins to the tcl interpreter
+yosys -import
+
+read_verilog $::env(DESIGN_TOP).v
+read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+hierarchy -check -auto-top
+# Start flow after library reading
+synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+
+# Read the design's timing constraints
+read_sdc $::env(DESIGN_TOP).input.sdc
+
+# Propagate the clocks
+propagate_clocks
+
+# Write the clocks to file
+set fh [open $::env(DESIGN_TOP).txt w]
+
+puts $fh [get_clocks]
+
+puts $fh [get_clocks -include_generated_clocks]
+
+puts $fh [get_clocks -include_generated_clocks clk2]
+
+puts $fh [get_clocks -of [get_nets clk_int_1 clk1] -include_generated_clocks clk_int_1]
+
+puts $fh [get_clocks -of [get_nets]]
+
+puts $fh [get_clocks -of [concat [get_nets clk2] [get_nets clk_int_1 clk]]]
+
+close $fh

--- a/sdc-plugin/tests/get_clocks/get_clocks.tcl
+++ b/sdc-plugin/tests/get_clocks/get_clocks.tcl
@@ -9,7 +9,8 @@ read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
 read_verilog -lib +/xilinx/cells_xtra.v
 hierarchy -check -auto-top
 # Start flow after library reading
-synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+synth_xilinx -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+#synth_xilinx
 
 # Read the design's timing constraints
 read_sdc $::env(DESIGN_TOP).input.sdc

--- a/sdc-plugin/tests/get_clocks/get_clocks.v
+++ b/sdc-plugin/tests/get_clocks/get_clocks.v
@@ -1,0 +1,35 @@
+module top(input clk,
+        input clk2,
+	input [1:0] in,
+	output [5:0] out );
+
+reg [1:0] cnt = 0;
+wire clk_int_1, clk_int_2;
+IBUF ibuf_inst(.I(clk), .O(ibuf_out));
+assign clk_int_1 = ibuf_out;
+assign clk_int_2 = clk_int_1;
+
+always @(posedge clk_int_2) begin
+	cnt <= cnt + 1;
+end
+
+middle middle_inst_1(.clk(ibuf_out), .out(out[2]));
+middle middle_inst_2(.clk(clk_int_1), .out(out[3]));
+middle middle_inst_3(.clk(clk_int_2), .out(out[4]));
+middle middle_inst_4(.clk(clk2), .out(out[5]));
+
+assign out[1:0] = {cnt[0], in[0]};
+endmodule
+
+module middle(input clk,
+	output out);
+
+reg [1:0] cnt = 0;
+wire clk_int;
+assign clk_int = clk;
+always @(posedge clk_int) begin
+	cnt <= cnt + 1;
+end
+
+assign out = cnt[0];
+endmodule


### PR DESCRIPTION
This PR depends on #51 
It add the `-of` and `-include_generated_clocks` switches to `get_clocks` command since they are used in the linux litex SDC.