### PR TITLE
Clock propagation enhancement

### DIFF
--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -30,7 +30,7 @@ void Clock::Add(const std::string& name, RTLIL::Wire* wire, float period,
     wire->set_bool_attribute(RTLIL::escape_id("IS_PROPAGATED"), type == PROPAGATED);
     wire->set_string_attribute(RTLIL::escape_id("CLASS"), "clock");
     wire->set_string_attribute(RTLIL::escape_id("NAME"), name);
-    wire->set_string_attribute(RTLIL::escape_id("SOURCE_PINS"),
+    wire->set_string_attribute(RTLIL::escape_id("SOURCE_WIRES"),
                                Clock::WireName(wire));
     wire->set_string_attribute(RTLIL::escape_id("PERIOD"),
                                std::to_string(period));
@@ -124,9 +124,9 @@ std::string Clock::WireName(RTLIL::Wire* clock_wire) {
     return AddEscaping(RTLIL::unescape_id(clock_wire->name));
 }
 
-std::string Clock::SourcePinName(RTLIL::Wire* clock_wire) {
-    if (clock_wire->has_attribute(RTLIL::escape_id("SOURCE_PINS"))) {
-	return clock_wire->get_string_attribute(RTLIL::escape_id("SOURCE_PINS"));
+std::string Clock::SourceWireName(RTLIL::Wire* clock_wire) {
+    if (clock_wire->has_attribute(RTLIL::escape_id("SOURCE_WIRES"))) {
+	return clock_wire->get_string_attribute(RTLIL::escape_id("SOURCE_WIRES"));
     }
     return Name(clock_wire);
 }

--- a/sdc-plugin/clocks.cc
+++ b/sdc-plugin/clocks.cc
@@ -114,11 +114,18 @@ std::string Clock::Name(RTLIL::Wire* clock_wire) {
     return WireName(clock_wire);
 }
 
-std::string Clock::WireName(RTLIL::Wire* wire) {
-    if (!wire) {
+std::string Clock::WireName(RTLIL::Wire* clock_wire) {
+    if (!clock_wire) {
 	return std::string();
     }
-    return AddEscaping(RTLIL::unescape_id(wire->name));
+    return AddEscaping(RTLIL::unescape_id(clock_wire->name));
+}
+
+std::string Clock::SourcePinName(RTLIL::Wire* clock_wire) {
+    if (clock_wire->has_attribute(RTLIL::escape_id("SOURCE_PINS"))) {
+	return clock_wire->get_string_attribute(RTLIL::escape_id("SOURCE_PINS"));
+    }
+    return Name(clock_wire);
 }
 
 const std::map<std::string, RTLIL::Wire*> Clocks::GetClocks(

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -46,6 +46,7 @@ class Clock {
     static std::string AddEscaping(const std::string& name) {
 	return std::regex_replace(name, std::regex{"\\$"}, "\\$");
     }
+    static std::string SourcePinName(RTLIL::Wire* clock_wire);
 
    private:
     static std::pair<float, float> Waveform(RTLIL::Wire* clock_wire);

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -32,12 +32,13 @@ class Propagation;
 
 class Clock {
    public:
+    enum ClockType { EXPLICIT, GENERATED, PROPAGATED };
     static void Add(const std::string& name, RTLIL::Wire* wire, float period,
-                    float rising_edge, float falling_edge);
+                    float rising_edge, float falling_edge, ClockType type);
     static void Add(const std::string& name, std::vector<RTLIL::Wire*> wires,
-                    float period, float rising_edge, float falling_edge);
+                    float period, float rising_edge, float falling_edge, ClockType type);
     static void Add(RTLIL::Wire* wire, float period, float rising_edge,
-                    float falling_edge);
+                    float falling_edge, ClockType type);
     static float Period(RTLIL::Wire* clock_wire);
     static float RisingEdge(RTLIL::Wire* clock_wire);
     static float FallingEdge(RTLIL::Wire* clock_wire);
@@ -47,9 +48,22 @@ class Clock {
 	return std::regex_replace(name, std::regex{"\\$"}, "\\$");
     }
     static std::string SourcePinName(RTLIL::Wire* clock_wire);
+    static bool IsPropagated(RTLIL::Wire* wire) {
+	return GetClockWireBoolAttribute(wire, "IS_PROPAGATED");
+    }
+
+    static bool IsGenerated(RTLIL::Wire* wire) {
+	return GetClockWireBoolAttribute(wire, "IS_GENERATED");
+    }
+
+    static bool IsExplicit(RTLIL::Wire* wire) {
+	return GetClockWireBoolAttribute(wire, "IS_EXPLICIT");
+    }
 
    private:
     static std::pair<float, float> Waveform(RTLIL::Wire* clock_wire);
+
+    static bool GetClockWireBoolAttribute(RTLIL::Wire* wire, const std::string& attribute_name);
 };
 
 class Clocks {

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -32,6 +32,10 @@ class Propagation;
 
 class Clock {
    public:
+    // We distinguish the following types of clock:
+    // * EXPLICIT - added with create_clocks command
+    // * GENERATED - propagated from explicit clocks changing the clock's parameters
+    // * PROPAGATED - propagated from explicit clocks but with the same parameters as the driver
     enum ClockType { EXPLICIT, GENERATED, PROPAGATED };
     static void Add(const std::string& name, RTLIL::Wire* wire, float period,
                     float rising_edge, float falling_edge, ClockType type);

--- a/sdc-plugin/clocks.h
+++ b/sdc-plugin/clocks.h
@@ -47,7 +47,7 @@ class Clock {
     static std::string AddEscaping(const std::string& name) {
 	return std::regex_replace(name, std::regex{"\\$"}, "\\$");
     }
-    static std::string SourcePinName(RTLIL::Wire* clock_wire);
+    static std::string SourceWireName(RTLIL::Wire* clock_wire);
     static bool IsPropagated(RTLIL::Wire* wire) {
 	return GetClockWireBoolAttribute(wire, "IS_PROPAGATED");
     }

--- a/sdc-plugin/propagation.cc
+++ b/sdc-plugin/propagation.cc
@@ -37,7 +37,7 @@ void Propagation::PropagateThroughBuffers(Buffer buffer) {
 	    path_delay += buffer.delay;
 	    Clock::Add(wire, Clock::Period(clock_wire),
 	               Clock::RisingEdge(clock_wire) + path_delay,
-	               Clock::FallingEdge(clock_wire) + path_delay);
+	               Clock::FallingEdge(clock_wire) + path_delay, Clock::PROPAGATED);
 	}
     }
 }
@@ -169,7 +169,7 @@ void NaturalPropagation::Run() {
 	auto aliases = FindAliasWires(clock_wire);
 	Clock::Add(Clock::WireName(clock_wire), aliases,
 	           Clock::Period(clock_wire), Clock::RisingEdge(clock_wire),
-	           Clock::FallingEdge(clock_wire));
+	           Clock::FallingEdge(clock_wire), Clock::PROPAGATED);
     }
 #ifdef SDC_DEBUG
     log("Finish natural clock propagation\n\n");
@@ -253,7 +253,7 @@ void ClockDividerPropagation::PropagateClocksForCellType(
 		float clkout_rising_edge(pll.clkout_rising_edge.at(output));
 		float clkout_falling_edge(pll.clkout_falling_edge.at(output));
 		Clock::Add(wire, clkout_period, clkout_rising_edge,
-		           clkout_falling_edge);
+		           clkout_falling_edge, Clock::GENERATED);
 	    }
 	}
     }

--- a/sdc-plugin/propagation.h
+++ b/sdc-plugin/propagation.h
@@ -34,6 +34,8 @@ class Propagation {
     RTLIL::Design* design_;
     Pass* pass_;
 
+    // This propagation doesn't change the clock so the sink wire is only marked
+    // as propagated clock signal, but has the properties of the driving clock
     void PropagateThroughBuffers(Buffer buffer);
     std::vector<RTLIL::Wire*> FindSinkWiresForCellType(
         RTLIL::Wire* driver_wire, const std::string& cell_type,

--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -169,7 +169,7 @@ struct CreateClockCmd : public Pass {
 	    rising_edge = 0;
 	    falling_edge = period / 2;
 	}
-	Clock::Add(name, selected_wires, period, rising_edge, falling_edge);
+	Clock::Add(name, selected_wires, period, rising_edge, falling_edge, Clock::EXPLICIT);
     }
 
     void AddWirePrefix(std::vector<std::string>& args, size_t argidx) {

--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -46,9 +46,13 @@ void SdcWriter::WriteSdc(RTLIL::Design* design, std::ostream& file) {
 
 void SdcWriter::WriteClocks(RTLIL::Design* design, std::ostream& file) {
     for (auto& clock : Clocks::GetClocks(design)) {
-	// FIXME: Input port nets are not found in VPR
 	auto& clock_wire = clock.second;
+	// FIXME: Input port nets are not found in VPR
 	if (clock_wire->port_input) {
+	    continue;
+	}
+	// Write out only GENERATED and EXPLICIT clocks
+	if (Clock::IsPropagated(clock_wire)) {
 	    continue;
 	}
 	file << "create_clock -period " << Clock::Period(clock_wire);

--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -54,7 +54,7 @@ void SdcWriter::WriteClocks(RTLIL::Design* design, std::ostream& file) {
 	file << "create_clock -period " << Clock::Period(clock_wire);
 	file << " -waveform {" << Clock::RisingEdge(clock_wire) << " "
 	     << Clock::FallingEdge(clock_wire) << "}";
-	file << " " << Clock::WireName(clock_wire);
+	file << " " << Clock::SourcePinName(clock_wire);
 	file << std::endl;
     }
 }

--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -58,7 +58,7 @@ void SdcWriter::WriteClocks(RTLIL::Design* design, std::ostream& file) {
 	file << "create_clock -period " << Clock::Period(clock_wire);
 	file << " -waveform {" << Clock::RisingEdge(clock_wire) << " "
 	     << Clock::FallingEdge(clock_wire) << "}";
-	file << " " << Clock::SourcePinName(clock_wire);
+	file << " " << Clock::SourceWireName(clock_wire);
 	file << std::endl;
     }
 }

--- a/sdc-plugin/tests/counter/counter.golden.sdc
+++ b/sdc-plugin/tests/counter/counter.golden.sdc
@@ -1,6 +1,1 @@
-create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1801
-create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1803
 create_clock -period 10 -waveform {0 5} clk_int_1
-create_clock -period 10 -waveform {0 5} ibuf_proxy_out
-create_clock -period 10 -waveform {0 5} middle_inst_1.clk_int
-create_clock -period 10 -waveform {0 5} middle_inst_4.clk

--- a/sdc-plugin/tests/counter/counter.golden.txt
+++ b/sdc-plugin/tests/counter/counter.golden.txt
@@ -1,1 +1,2 @@
-{$auto$clkbufmap.cc:262:execute$1801} {$auto$clkbufmap.cc:262:execute$1803} clk clk2 clk_int_1 ibuf_proxy_out middle_inst_1.clk_int middle_inst_4.clk
+clk clk2 clk_int_1
+clk clk2 clk_int_1

--- a/sdc-plugin/tests/counter/counter.tcl
+++ b/sdc-plugin/tests/counter/counter.tcl
@@ -18,8 +18,8 @@ propagate_clocks
 
 # Write the clocks to file
 set fh [open $::env(DESIGN_TOP).txt w]
-set clocks [get_clocks]
-puts $fh $clocks
+puts $fh [get_clocks]
+puts $fh [get_clocks -include_generated_clocks]
 close $fh
 
 # Write out the SDC file after the clock propagation step

--- a/sdc-plugin/tests/counter2/counter.txt
+++ b/sdc-plugin/tests/counter2/counter.txt
@@ -1,1 +1,0 @@
-clk_int_1 clk ibuf_proxy_out {$auto$clkbufmap.cc:247:execute$1918} {$auto$clkbufmap.cc:247:execute$1920} middle_inst_1.clk_int middle_inst_4.clk

--- a/sdc-plugin/tests/counter2/counter2.golden.sdc
+++ b/sdc-plugin/tests/counter2/counter2.golden.sdc
@@ -1,6 +1,1 @@
-create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1801
-create_clock -period 10 -waveform {1 6} \$auto\$clkbufmap.cc:262:execute\$1803
 create_clock -period 10 -waveform {0 5} clk_int_1
-create_clock -period 10 -waveform {0 5} ibuf_proxy_out
-create_clock -period 10 -waveform {0 5} middle_inst_1.clk_int
-create_clock -period 10 -waveform {1 6} middle_inst_4.clk

--- a/sdc-plugin/tests/counter2/counter2.golden.txt
+++ b/sdc-plugin/tests/counter2/counter2.golden.txt
@@ -1,1 +1,1 @@
-{$auto$clkbufmap.cc:262:execute$1801} {$auto$clkbufmap.cc:262:execute$1803} clk clk2 clk_int_1 ibuf_proxy_out middle_inst_1.clk_int middle_inst_4.clk
+clk clk2 clk_int_1

--- a/sdc-plugin/tests/get_clocks/get_clocks.golden.txt
+++ b/sdc-plugin/tests/get_clocks/get_clocks.golden.txt
@@ -1,5 +1,5 @@
 clk clk2 clk_int_1
-clk clk2 clk_int_1
+{$auto$clkbufmap.cc:262:execute$1845} clk clk2 clk_int_1
 clk2
 clk_int_1
 clk clk2 clk_int_1

--- a/sdc-plugin/tests/get_clocks/get_clocks.golden.txt
+++ b/sdc-plugin/tests/get_clocks/get_clocks.golden.txt
@@ -1,6 +1,6 @@
-{$auto$clkbufmap.cc:262:execute$1800} {$auto$clkbufmap.cc:262:execute$1802} clk clk2 clk_int_1 middle_inst_1.clk_int middle_inst_4.clk
-{$auto$clkbufmap.cc:262:execute$1800} {$auto$clkbufmap.cc:262:execute$1802} clk clk2 clk_int_1 middle_inst_1.clk_int middle_inst_4.clk
+clk clk2 clk_int_1
+clk clk2 clk_int_1
 clk2
 clk_int_1
-clk clk2 clk_int_1 middle_inst_1.clk_int middle_inst_4.clk
+clk clk2 clk_int_1
 clk clk2 clk_int_1

--- a/sdc-plugin/tests/get_clocks/get_clocks.v
+++ b/sdc-plugin/tests/get_clocks/get_clocks.v
@@ -4,13 +4,34 @@ module top(input clk,
 	output [5:0] out );
 
 reg [1:0] cnt = 0;
+reg [1:0] cnt2 = 0;
 wire clk_int_1, clk_int_2;
 IBUF ibuf_inst(.I(clk), .O(ibuf_out));
 assign clk_int_1 = ibuf_out;
 assign clk_int_2 = clk_int_1;
 
+PLLE2_ADV #(
+	.CLKFBOUT_MULT(4'd12),
+	.CLKIN1_PERIOD(10.0),
+	.CLKOUT0_DIVIDE(4'd12),
+	.CLKOUT0_PHASE(90.0),
+	.DIVCLK_DIVIDE(1'd1),
+	.REF_JITTER1(0.01),
+	.STARTUP_WAIT("FALSE")
+) PLLE2_ADV (
+	.CLKFBIN(builder_pll_fb),
+	.CLKIN1(clk),
+	.RST(cpu_reset),
+	.CLKFBOUT(builder_pll_fb),
+	.CLKOUT0(main_clkout0),
+);
+
 always @(posedge clk_int_2) begin
 	cnt <= cnt + 1;
+end
+
+always @(posedge main_clkout0) begin
+	cnt2 <= cnt2 + 1;
 end
 
 middle middle_inst_1(.clk(ibuf_out), .out(out[2]));
@@ -18,7 +39,7 @@ middle middle_inst_2(.clk(clk_int_1), .out(out[3]));
 middle middle_inst_3(.clk(clk_int_2), .out(out[4]));
 middle middle_inst_4(.clk(clk2), .out(out[5]));
 
-assign out[1:0] = {cnt[0], in[0]};
+assign out[2:0] = {cnt2[0], cnt[0], in[0]};
 endmodule
 
 module middle(input clk,

--- a/sdc-plugin/tests/pll/pll.golden.sdc
+++ b/sdc-plugin/tests/pll/pll.golden.sdc
@@ -1,8 +1,3 @@
-create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1715
 create_clock -period 10 -waveform {2.5 7.5} \$auto\$clkbufmap.cc:262:execute\$1717
 create_clock -period 2.5 -waveform {0 1.25} \$auto\$clkbufmap.cc:262:execute\$1719
 create_clock -period 5 -waveform {1.25 3.75} \$auto\$clkbufmap.cc:262:execute\$1721
-create_clock -period 10 -waveform {0 5} \$techmap1617\FDCE_0.C
-create_clock -period 10 -waveform {2.5 7.5} main_clkout0
-create_clock -period 2.5 -waveform {0 1.25} main_clkout1
-create_clock -period 5 -waveform {1.25 3.75} main_clkout2

--- a/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.golden.sdc
+++ b/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.golden.sdc
@@ -1,8 +1,3 @@
-create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1715
 create_clock -period 9.99999 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1717
 create_clock -period 5 -waveform {-2.5 0} \$auto\$clkbufmap.cc:262:execute\$1719
 create_clock -period 2.5 -waveform {-1.875 -0.624999} \$auto\$clkbufmap.cc:262:execute\$1721
-create_clock -period 10 -waveform {0 5} \$techmap1617\FDCE_0.C
-create_clock -period 9.99999 -waveform {0 5} main_clkout_x1
-create_clock -period 5 -waveform {-2.5 0} main_clkout_x2
-create_clock -period 2.5 -waveform {-1.875 -0.624999} main_clkout_x4

--- a/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.golden.sdc
+++ b/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.golden.sdc
@@ -1,3 +1,1 @@
-create_clock -period 10 -waveform {0 5} \$abc\$1699\$iopadmap\$clk
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1704
-create_clock -period 10 -waveform {0 5} main_clkout0

--- a/sdc-plugin/tests/pll_div/pll_div.golden.sdc
+++ b/sdc-plugin/tests/pll_div/pll_div.golden.sdc
@@ -1,8 +1,3 @@
-create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1715
 create_clock -period 20 -waveform {5 15} \$auto\$clkbufmap.cc:262:execute\$1717
 create_clock -period 5 -waveform {0 2.5} \$auto\$clkbufmap.cc:262:execute\$1719
 create_clock -period 10 -waveform {2.5 7.5} \$auto\$clkbufmap.cc:262:execute\$1721
-create_clock -period 10 -waveform {0 5} \$techmap1617\FDCE_0.C
-create_clock -period 20 -waveform {5 15} main_clkout0
-create_clock -period 5 -waveform {0 2.5} main_clkout1
-create_clock -period 10 -waveform {2.5 7.5} main_clkout2

--- a/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.golden.sdc
+++ b/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.golden.sdc
@@ -1,8 +1,3 @@
-create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1715
 create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1717
 create_clock -period 5 -waveform {-2.5 0} \$auto\$clkbufmap.cc:262:execute\$1719
 create_clock -period 2.5 -waveform {-1.875 -0.625} \$auto\$clkbufmap.cc:262:execute\$1721
-create_clock -period 10 -waveform {0 5} \$techmap1617\FDCE_0.C
-create_clock -period 10 -waveform {0 5} main_clkout_x1
-create_clock -period 5 -waveform {-2.5 0} main_clkout_x2
-create_clock -period 2.5 -waveform {-1.875 -0.625} main_clkout_x4


### PR DESCRIPTION
This PR aims at solving issue #53.

Added a distinction between three types of clocks:
* explicit - added with `create_clock` command 
* generated - propagated clocks that have different clock parameters than the master clock (like PLLs or MMCMs)
* propagated clocks - clock wires with the same clock parameters as their master clock
 