### PR TITLE
SDC: Skip adding clocks on dangling wires

### DIFF
--- a/sdc-plugin/propagation.h
+++ b/sdc-plugin/propagation.h
@@ -42,6 +42,7 @@ class Propagation {
     RTLIL::Cell* FindSinkCellOnPort(RTLIL::Wire* wire, const std::string& port);
     RTLIL::Wire* FindSinkWireOnPort(RTLIL::Cell* cell,
                                     const std::string& port_name);
+    bool WireHasSinkCell(RTLIL::Wire* wire);
 };
 
 class NaturalPropagation : public Propagation {

--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -13,6 +13,7 @@ TESTS = counter \
 	pll_div \
 	pll_fbout_phase \
 	pll_approx_equal \
+	pll_dangling_wires \
 	set_false_path \
 	set_max_delay \
 	set_clock_groups \
@@ -32,6 +33,7 @@ pll_verify = $(call diff_test,pll,sdc)
 pll_div_verify = $(call diff_test,pll_div,sdc)
 pll_fbout_phase_verify = $(call diff_test,pll_fbout_phase,sdc)
 pll_approx_equal_verify = $(call diff_test,pll_approx_equal,sdc)
+pll_dangling_wires_verify = $(call diff_test,pll_dangling_wires,sdc)
 set_false_path_verify = $(call diff_test,set_false_path,sdc)
 set_max_delay_verify = $(call diff_test,set_max_delay,sdc)
 set_clock_groups_verify = $(call diff_test,set_clock_groups,sdc)

--- a/sdc-plugin/tests/pll/pll.v
+++ b/sdc-plugin/tests/pll/pll.v
@@ -46,8 +46,6 @@ PLLE2_ADV #(
 	.CLKOUT0(main_clkout0),
 	.CLKOUT1(main_clkout1),
 	.CLKOUT2(main_clkout2),
-	.CLKOUT3(main_clkout3),
-	.CLKOUT4(main_clkout4),
 	.LOCKED(main_locked)
 );
 

--- a/sdc-plugin/tests/pll/pll.v
+++ b/sdc-plugin/tests/pll/pll.v
@@ -46,6 +46,8 @@ PLLE2_ADV #(
 	.CLKOUT0(main_clkout0),
 	.CLKOUT1(main_clkout1),
 	.CLKOUT2(main_clkout2),
+	.CLKOUT3(main_clkout3),
+	.CLKOUT4(main_clkout4),
 	.LOCKED(main_locked)
 );
 

--- a/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.golden.sdc
+++ b/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.golden.sdc
@@ -1,0 +1,3 @@
+create_clock -period 10 -waveform {0 5} \$abc\$1699\$iopadmap\$clk
+create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1704
+create_clock -period 10 -waveform {0 5} main_clkout0

--- a/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.input.sdc
+++ b/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.input.sdc
@@ -1,0 +1,1 @@
+create_clock -period 10 -waveform {0 5} clk

--- a/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.tcl
+++ b/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.tcl
@@ -1,0 +1,21 @@
+yosys -import
+plugin -i sdc
+# Import the commands from the plugins to the tcl interpreter
+yosys -import
+
+read_verilog $::env(DESIGN_TOP).v
+read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+hierarchy -check -auto-top
+
+# Start flow after library reading
+synth_xilinx -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+
+# Read the design timing constraints
+read_sdc $::env(DESIGN_TOP).input.sdc
+
+# Propagate the clocks
+propagate_clocks
+
+# Write out the SDC file after the clock propagation step
+write_sdc $::env(DESIGN_TOP).sdc

--- a/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.v
+++ b/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.v
@@ -1,0 +1,41 @@
+module top(
+	input clk,
+	input cpu_reset,
+	input data_in,
+	output data_out
+);
+
+wire data_out;
+wire builder_pll_fb;
+wire main_locked;
+
+PLLE2_ADV #(
+	.CLKFBOUT_MULT(4'd12),
+	.CLKIN1_PERIOD(10.0),
+	.CLKOUT0_DIVIDE(4'd12),
+	.CLKOUT0_PHASE(0.0),
+	.DIVCLK_DIVIDE(1'd1),
+	.REF_JITTER1(0.01),
+	.STARTUP_WAIT("FALSE")
+) PLLE2_ADV (
+	.CLKFBIN(builder_pll_fb),
+	.CLKIN1(clk),
+	.RST(cpu_reset),
+	.CLKFBOUT(builder_pll_fb),
+	.CLKOUT0(main_clkout0),
+	.CLKOUT1(main_clkout1),
+	.CLKOUT2(main_clkout2),
+	.CLKOUT3(main_clkout3),
+	.CLKOUT4(main_clkout4),
+	.LOCKED(main_locked)
+);
+
+FDCE FDCE_PLLx1_PH0 (
+	.D(data_in),
+	.C(main_clkout0),
+	.CE(1'b1),
+	.CLR(1'b0),
+	.Q(data_out)
+);
+
+endmodule


### PR DESCRIPTION
This PR fixes the problem found in https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1753#issuecomment-733165240
If the wire on the clock divider output doesn't drive any cells it won't be added to the list of generated clocks.