### PR TITLE
Fix compilation

### DIFF
--- a/bank_tiles.h
+++ b/bank_tiles.h
@@ -27,7 +27,7 @@ using BankTilesMap = std::unordered_map<int, std::string>;
 
 // Find the part's JSON file with information including the IO Banks
 // and extract the bank tiles.
-BankTilesMap get_bank_tiles(const std::string json_file_name) {
+inline BankTilesMap get_bank_tiles(const std::string json_file_name) {
 	BankTilesMap bank_tiles;
 	std::ifstream json_file(json_file_name);
 	if (!json_file.good()) {

--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -16,6 +16,8 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 #include <algorithm>
+#include <array>
+
 #include "clocks.h"
 #include "kernel/log.h"
 #include "kernel/register.h"


### PR DESCRIPTION
 * add missing include in xdc plug-in
 * make get_bank_tiles() an inline function to avoid duplicate
   symbols if all plugins are linked together.

Signed-off-by: Henner Zeller <h.zeller@acm.org>