### PR TITLE
SDC: Add include_propagated_clocks switch

### DIFF
--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -67,20 +67,33 @@ struct WriteSdcCmd : public Backend {
     void help() override
     {
         log("\n");
-        log("    write_sdc <filename>\n");
+        log("    write_sdc [-include_propagated_clocks] <filename>\n");
         log("\n");
         log("Write SDC file.\n");
+        log("\n");
+        log("    -include_propagated_clocks\n");
+        log("       Write out all propagated clocks");
         log("\n");
     }
 
     void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) override
     {
+        size_t argidx;
+        bool include_propagated = false;
         if (args.size() < 2) {
             log_cmd_error("Missing output file.\n");
         }
+        for (argidx = 1; argidx < args.size(); argidx++) {
+            std::string arg = args[argidx];
+            if (arg == "-include_propagated_clocks" && argidx + 1 < args.size()) {
+                include_propagated = true;
+                continue;
+            }
+            break;
+        }
         log("\nWriting out clock constraints file(SDC)\n");
-        extra_args(f, filename, args, 1);
-        sdc_writer_.WriteSdc(design, *f);
+        extra_args(f, filename, args, argidx);
+        sdc_writer_.WriteSdc(design, *f, include_propagated);
     }
 
     SdcWriter &sdc_writer_;

--- a/sdc-plugin/sdc_writer.cc
+++ b/sdc-plugin/sdc_writer.cc
@@ -31,15 +31,15 @@ void SdcWriter::AddClockGroup(ClockGroups::ClockGroup clock_group, ClockGroups::
     clock_groups_.Add(clock_group, relation);
 }
 
-void SdcWriter::WriteSdc(RTLIL::Design *design, std::ostream &file)
+void SdcWriter::WriteSdc(RTLIL::Design *design, std::ostream &file, bool include_propagated)
 {
-    WriteClocks(design, file);
+    WriteClocks(design, file, include_propagated);
     WriteFalsePaths(file);
     WriteMaxDelay(file);
     WriteClockGroups(file);
 }
 
-void SdcWriter::WriteClocks(RTLIL::Design *design, std::ostream &file)
+void SdcWriter::WriteClocks(RTLIL::Design *design, std::ostream &file, bool include_propagated)
 {
     for (auto &clock : Clocks::GetClocks(design)) {
         auto &clock_wire = clock.second;
@@ -48,7 +48,7 @@ void SdcWriter::WriteClocks(RTLIL::Design *design, std::ostream &file)
             continue;
         }
         // Write out only GENERATED and EXPLICIT clocks
-        if (Clock::IsPropagated(clock_wire)) {
+        if (Clock::IsPropagated(clock_wire) and !include_propagated) {
             continue;
         }
         file << "create_clock -period " << Clock::Period(clock_wire);

--- a/sdc-plugin/sdc_writer.h
+++ b/sdc-plugin/sdc_writer.h
@@ -59,10 +59,10 @@ class SdcWriter
     void AddFalsePath(FalsePath false_path);
     void SetMaxDelay(TimingPath timing_path);
     void AddClockGroup(ClockGroups::ClockGroup clock_group, ClockGroups::ClockGroupRelation relation);
-    void WriteSdc(RTLIL::Design *design, std::ostream &file);
+    void WriteSdc(RTLIL::Design *design, std::ostream &file, bool include_propagated);
 
   private:
-    void WriteClocks(RTLIL::Design *design, std::ostream &file);
+    void WriteClocks(RTLIL::Design *design, std::ostream &file, bool include_propagated);
     void WriteFalsePaths(std::ostream &file);
     void WriteMaxDelay(std::ostream &file);
     void WriteClockGroups(std::ostream &file);

--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -14,6 +14,7 @@ TESTS = counter \
 	pll_fbout_phase \
 	pll_approx_equal \
 	pll_dangling_wires \
+	pll_propagated \
 	set_false_path \
 	set_max_delay \
 	set_clock_groups \
@@ -34,6 +35,7 @@ pll_div_verify = $(call diff_test,pll_div,sdc)
 pll_fbout_phase_verify = $(call diff_test,pll_fbout_phase,sdc)
 pll_approx_equal_verify = $(call diff_test,pll_approx_equal,sdc)
 pll_dangling_wires_verify = $(call diff_test,pll_dangling_wires,sdc)
+pll_propagated_verify = $(call diff_test,pll_propagated,sdc)
 set_false_path_verify = $(call diff_test,set_false_path,sdc)
 set_max_delay_verify = $(call diff_test,set_max_delay,sdc)
 set_clock_groups_verify = $(call diff_test,set_clock_groups,sdc)

--- a/sdc-plugin/tests/pll_propagated/pll_propagated.golden.sdc
+++ b/sdc-plugin/tests/pll_propagated/pll_propagated.golden.sdc
@@ -1,0 +1,8 @@
+create_clock -period 10 -waveform {0 5} \$auto\$clkbufmap.cc:262:execute\$1715
+create_clock -period 10 -waveform {2.5 7.5} \$auto\$clkbufmap.cc:262:execute\$1717
+create_clock -period 2.5 -waveform {0 1.25} \$auto\$clkbufmap.cc:262:execute\$1719
+create_clock -period 5 -waveform {1.25 3.75} \$auto\$clkbufmap.cc:262:execute\$1721
+create_clock -period 10 -waveform {0 5} \$techmap1617\FDCE_0.C
+create_clock -period 10 -waveform {2.5 7.5} main_clkout0
+create_clock -period 2.5 -waveform {0 1.25} main_clkout1
+create_clock -period 5 -waveform {1.25 3.75} main_clkout2

--- a/sdc-plugin/tests/pll_propagated/pll_propagated.input.sdc
+++ b/sdc-plugin/tests/pll_propagated/pll_propagated.input.sdc
@@ -1,0 +1,1 @@
+create_clock -period 10 -waveform {0 5} clk

--- a/sdc-plugin/tests/pll_propagated/pll_propagated.tcl
+++ b/sdc-plugin/tests/pll_propagated/pll_propagated.tcl
@@ -1,0 +1,21 @@
+yosys -import
+plugin -i sdc
+# Import the commands from the plugins to the tcl interpreter
+yosys -import
+
+read_verilog $::env(DESIGN_TOP).v
+read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+hierarchy -check -auto-top
+
+# Start flow after library reading
+synth_xilinx -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+
+# Read the design timing constraints
+read_sdc $::env(DESIGN_TOP).input.sdc
+
+# Propagate the clocks
+propagate_clocks
+
+# Write out the SDC file after the clock propagation step
+write_sdc -include_propagated_clocks $::env(DESIGN_TOP).sdc

--- a/sdc-plugin/tests/pll_propagated/pll_propagated.v
+++ b/sdc-plugin/tests/pll_propagated/pll_propagated.v
@@ -1,0 +1,91 @@
+module top(
+	input clk,
+	input cpu_reset,
+	input data_in,
+	output[5:0] data_out
+);
+
+wire [5:0] data_out;
+wire builder_pll_fb;
+wire fdce_0_out, fdce_1_out;
+wire main_locked;
+
+FDCE FDCE_0 (
+	.D(data_in),
+	.C(clk),
+	.CE(1'b1),
+	.CLR(1'b0),
+	.Q(fdce_0_out)
+);
+
+FDCE FDCE_1 (
+	.D(fdce_0_out),
+	.C(clk),
+	.CE(1'b1),
+	.CLR(1'b0),
+	.Q(data_out[0])
+);
+
+PLLE2_ADV #(
+	.CLKFBOUT_MULT(4'd12),
+	.CLKIN1_PERIOD(10.0),
+	.CLKOUT0_DIVIDE(4'd12),
+	.CLKOUT0_PHASE(90.0),
+	.CLKOUT1_DIVIDE(2'd3),
+	.CLKOUT1_PHASE(0.0),
+	.CLKOUT2_DIVIDE(3'd6),
+	.CLKOUT2_PHASE(90.0),
+	.DIVCLK_DIVIDE(1'd1),
+	.REF_JITTER1(0.01),
+	.STARTUP_WAIT("FALSE")
+) PLLE2_ADV (
+	.CLKFBIN(builder_pll_fb),
+	.CLKIN1(clk),
+	.RST(cpu_reset),
+	.CLKFBOUT(builder_pll_fb),
+	.CLKOUT0(main_clkout0),
+	.CLKOUT1(main_clkout1),
+	.CLKOUT2(main_clkout2),
+	.LOCKED(main_locked)
+);
+
+FDCE FDCE_PLLx1_PH90 (
+	.D(data_in),
+	.C(main_clkout0),
+	.CE(1'b1),
+	.CLR(1'b0),
+	.Q(data_out[1])
+);
+
+FDCE FDCE_PLLx4_PH0_0 (
+	.D(data_in),
+	.C(main_clkout1),
+	.CE(1'b1),
+	.CLR(1'b0),
+	.Q(data_out[2])
+);
+
+FDCE FDCE_PLLx4_PH0_1 (
+	.D(data_in),
+	.C(main_clkout1),
+	.CE(1'b1),
+	.CLR(1'b0),
+	.Q(data_out[3])
+);
+
+FDCE FDCE_PLLx4_PH0_2 (
+	.D(data_in),
+	.C(main_clkout1),
+	.CE(1'b1),
+	.CLR(1'b0),
+	.Q(data_out[4])
+);
+
+FDCE FDCE_PLLx2_PH90_0 (
+	.D(data_in),
+	.C(main_clkout2),
+	.CE(1'b1),
+	.CLR(1'b0),
+	.Q(data_out[5])
+);
+endmodule


### PR DESCRIPTION
This PR solves issue #64 by adding the `-include_propagated_clocks` switch which adds all propagated clocks to the written SDC.