### PR TITLE
In tests: Use $::env(DESIGN_TOP) where it isn't already.

### DIFF
--- a/design_introspection-plugin/tests/get_cells/get_cells.tcl
+++ b/design_introspection-plugin/tests/get_cells/get_cells.tcl
@@ -3,7 +3,7 @@ plugin -i design_introspection
 #Import the commands from the plugins to the tcl interpreter
 yosys -import
 
-read_verilog get_cells.v
+read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 

--- a/design_introspection-plugin/tests/get_nets/get_nets.tcl
+++ b/design_introspection-plugin/tests/get_nets/get_nets.tcl
@@ -3,7 +3,7 @@ plugin -i design_introspection
 #Import the commands from the plugins to the tcl interpreter
 yosys -import
 
-read_verilog get_nets.v
+read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 

--- a/design_introspection-plugin/tests/get_pins/get_pins.tcl
+++ b/design_introspection-plugin/tests/get_pins/get_pins.tcl
@@ -3,7 +3,7 @@ plugin -i design_introspection
 #Import the commands from the plugins to the tcl interpreter
 yosys -import
 
-read_verilog get_pins.v
+read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 

--- a/design_introspection-plugin/tests/get_ports/get_ports.tcl
+++ b/design_introspection-plugin/tests/get_ports/get_ports.tcl
@@ -3,7 +3,7 @@ plugin -i design_introspection
 #Import the commands from the plugins to the tcl interpreter
 yosys -import
 
-read_verilog get_ports.v
+read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 help get_ports

--- a/get_count-plugin/tests/simple/simple.tcl
+++ b/get_count-plugin/tests/simple/simple.tcl
@@ -1,7 +1,7 @@
 yosys plugin -i get_count
 yosys -import
 
-read_verilog -icells simple.v
+read_verilog -icells $::env(DESIGN_TOP).v
 hierarchy -auto-top
 
 set n [get_count -modules my_gate]

--- a/sdc-plugin/tests/set_clock_groups/set_clock_groups.tcl
+++ b/sdc-plugin/tests/set_clock_groups/set_clock_groups.tcl
@@ -3,7 +3,7 @@ plugin -i sdc
 #Import the commands from the plugins to the tcl interpreter
 yosys -import
 
-read_verilog set_clock_groups.v
+read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 

--- a/selection-plugin/tests/counter/counter.tcl
+++ b/selection-plugin/tests/counter/counter.tcl
@@ -27,7 +27,7 @@ proc test_selection { rfh selection } {
     }
 }
 
-read_verilog counter.v
+read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
 read_verilog -lib +/xilinx/cells_xtra.v
 hierarchy -check -auto-top

--- a/xdc-plugin/tests/minilitex_ddr_arty/minilitex_ddr_arty.tcl
+++ b/xdc-plugin/tests/minilitex_ddr_arty/minilitex_ddr_arty.tcl
@@ -5,7 +5,7 @@ plugin -i xdc
 yosys -import
 
 read_verilog $::env(DESIGN_TOP).v
-read_verilog VexRiscv_Lite.v
+read_verilog [file dirname [info script]]/VexRiscv_Lite.v
 # -flatten is used to ensure that the output eblif has only one module.
 # Some of symbiflow expects eblifs with only one module.
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp


### PR DESCRIPTION
This makes all tests use the same concept for accessing the
test verilog file in question. It also makes it possible to
run tests from different directories if only DESIGN_TOP is set
correctly.

In one place, a filename is resolved intended relative to the script,
but currently requires the script to be executed in the same
directory; make that location independent by reading it
relative to [file dirname [info script]]

Signed-off-by: Henner Zeller <h.zeller@acm.org>