### PR TITLE
Use install instead of cp for install purposes.

### DIFF
--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -48,8 +48,7 @@ $(NAME).so: $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
 
 install_plugin: $(NAME).so
-	mkdir -p $(PLUGINS_DIR)
-	cp $< $(PLUGINS_DIR)/$<
+	install -D $< $(PLUGINS_DIR)/$<
 
 test:
 	$(MAKE) -C tests all

--- a/xdc-plugin/Makefile
+++ b/xdc-plugin/Makefile
@@ -4,7 +4,6 @@ include ../Makefile_plugin.common
 VERILOG_MODULES = BANK.v
 
 install_modules: $(VERILOG_MODULES)
-	mkdir -p $(PLUGINS_DIR)/fasm_extra_modules/
-	cp $< $(PLUGINS_DIR)/fasm_extra_modules/$<
+	install -D $< $(PLUGINS_DIR)/fasm_extra_modules/$<
 
 install: install_modules


### PR DESCRIPTION
The install utility will set the proper permissions for the file
at hand while cp just sets the permissions at the destination
it gets from the original file - which might be totally wrong
depending on the users' umask.

Signed-off-by: Henner Zeller <h.zeller@acm.org>