### PR TITLE
Load plugins only if the symbol we're interested in is not there yet.

### DIFF
--- a/design_introspection-plugin/tests/get_cells/get_cells.tcl
+++ b/design_introspection-plugin/tests/get_cells/get_cells.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i design_introspection
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_cells] == {} } { plugin -i design_introspection }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.

--- a/design_introspection-plugin/tests/get_nets/get_nets.tcl
+++ b/design_introspection-plugin/tests/get_nets/get_nets.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i design_introspection
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_nets] == {} } { plugin -i design_introspection }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.

--- a/design_introspection-plugin/tests/get_pins/get_pins.tcl
+++ b/design_introspection-plugin/tests/get_pins/get_pins.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i design_introspection
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_pins] == {} } { plugin -i design_introspection }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.

--- a/design_introspection-plugin/tests/get_ports/get_ports.tcl
+++ b/design_introspection-plugin/tests/get_ports/get_ports.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i design_introspection
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_ports] == {} } { plugin -i design_introspection }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.

--- a/get_count-plugin/tests/simple/simple.tcl
+++ b/get_count-plugin/tests/simple/simple.tcl
@@ -1,5 +1,6 @@
-yosys plugin -i get_count
 yosys -import
+if { [info procs get_count] == {} } { plugin -i get_count }
+yosys -import # ingest new plugin commands
 
 read_verilog -icells $::env(DESIGN_TOP).v
 hierarchy -auto-top

--- a/integrateinv-plugin/tests/fanout/fanout.tcl
+++ b/integrateinv-plugin/tests/fanout/fanout.tcl
@@ -1,5 +1,6 @@
 yosys -import
-plugin -i integrateinv
+if { [info procs integrateinv] == {} } { plugin -i integrateinv }
+yosys -import  ;# ingest plugin commands
 
 read_verilog -icells $::env(DESIGN_TOP).v
 hierarchy -check -auto-top

--- a/integrateinv-plugin/tests/hierarchy/hierarchy.tcl
+++ b/integrateinv-plugin/tests/hierarchy/hierarchy.tcl
@@ -1,5 +1,6 @@
 yosys -import
-plugin -i integrateinv
+if { [info procs integrateinv] == {} } { plugin -i integrateinv }
+yosys -import  ;# ingest plugin commands
 
 read_verilog -icells $::env(DESIGN_TOP).v
 hierarchy -check -auto-top

--- a/integrateinv-plugin/tests/multi_bit/multi_bit.tcl
+++ b/integrateinv-plugin/tests/multi_bit/multi_bit.tcl
@@ -1,5 +1,6 @@
 yosys -import
-plugin -i integrateinv
+if { [info procs integrateinv] == {} } { plugin -i integrateinv }
+yosys -import  ;# ingest plugin commands
 
 read_verilog -icells $::env(DESIGN_TOP).v
 hierarchy -check -auto-top

--- a/integrateinv-plugin/tests/single_bit/single_bit.tcl
+++ b/integrateinv-plugin/tests/single_bit/single_bit.tcl
@@ -1,5 +1,6 @@
 yosys -import
-plugin -i integrateinv
+if { [info procs integrateinv] == {} } { plugin -i integrateinv }
+yosys -import  ;# ingest plugin commands
 
 read_verilog -icells $::env(DESIGN_TOP).v
 hierarchy -check -auto-top

--- a/integrateinv-plugin/tests/toplevel/toplevel.tcl
+++ b/integrateinv-plugin/tests/toplevel/toplevel.tcl
@@ -1,5 +1,6 @@
 yosys -import
-plugin -i integrateinv
+if { [info procs integrateinv] == {} } { plugin -i integrateinv }
+yosys -import  ;# ingest plugin commands
 
 read_verilog -icells $::env(DESIGN_TOP).v
 hierarchy -check -auto-top

--- a/params-plugin/tests/pll/pll.tcl
+++ b/params-plugin/tests/pll/pll.tcl
@@ -1,8 +1,6 @@
 yosys -import
-plugin -i xdc
-plugin -i params
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs getparam] == {} } { plugin -i params }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/counter/counter.tcl
+++ b/sdc-plugin/tests/counter/counter.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/counter2/counter2.tcl
+++ b/sdc-plugin/tests/counter2/counter2.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/get_clocks/get_clocks.tcl
+++ b/sdc-plugin/tests/get_clocks/get_clocks.tcl
@@ -1,8 +1,7 @@
 yosys -import
-plugin -i sdc
-plugin -i design_introspection
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+if { [info procs get_nets] == {} } { plugin -i design_introspection }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/period_check/period_check.tcl
+++ b/sdc-plugin/tests/period_check/period_check.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/period_format_check/period_format_check.tcl
+++ b/sdc-plugin/tests/period_format_check/period_format_check.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/pll/pll.tcl
+++ b/sdc-plugin/tests/pll/pll.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.tcl
+++ b/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.tcl
+++ b/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/pll_div/pll_div.tcl
+++ b/sdc-plugin/tests/pll_div/pll_div.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.tcl
+++ b/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/pll_propagated/pll_propagated.tcl
+++ b/sdc-plugin/tests/pll_propagated/pll_propagated.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/sdc-plugin/tests/restore_from_json/restore_from_json.tcl
+++ b/sdc-plugin/tests/restore_from_json/restore_from_json.tcl
@@ -1,8 +1,6 @@
 yosys -import
-
-plugin -i sdc
-
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 synth_xilinx

--- a/sdc-plugin/tests/set_clock_groups/set_clock_groups.tcl
+++ b/sdc-plugin/tests/set_clock_groups/set_clock_groups.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.

--- a/sdc-plugin/tests/set_false_path/set_false_path.tcl
+++ b/sdc-plugin/tests/set_false_path/set_false_path.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.

--- a/sdc-plugin/tests/set_max_delay/set_max_delay.tcl
+++ b/sdc-plugin/tests/set_max_delay/set_max_delay.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 # Some of symbiflow expects eblifs with only one module.

--- a/sdc-plugin/tests/waveform_check/waveform_check.tcl
+++ b/sdc-plugin/tests/waveform_check/waveform_check.tcl
@@ -1,7 +1,6 @@
 yosys -import
-plugin -i sdc
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v

--- a/selection-plugin/tests/counter/counter.tcl
+++ b/selection-plugin/tests/counter/counter.tcl
@@ -1,8 +1,6 @@
 yosys -import
-plugin -i selection
-
-# Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs selection_to_tcl_list] == {} } { plugin -i selection }
+yosys -import  ;# ingest plugin commands
 
 proc selection_to_tcl_list_through_file { selection } {
     set file_name "[pid].txt"

--- a/xdc-plugin/tests/counter/counter.tcl
+++ b/xdc-plugin/tests/counter/counter.tcl
@@ -1,8 +1,7 @@
 yosys -import
-plugin -i design_introspection
-plugin -i xdc
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_ports] == {} } { plugin -i design_introspection }
+if { [info procs read_xdc] == {} } { plugin -i xdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 

--- a/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.tcl
+++ b/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.tcl
@@ -1,8 +1,7 @@
 yosys -import
-plugin -i design_introspection
-plugin -i xdc
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_ports] == {} } { plugin -i design_introspection }
+if { [info procs read_xdc] == {} } { plugin -i xdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 

--- a/xdc-plugin/tests/minilitex_ddr_arty/minilitex_ddr_arty.tcl
+++ b/xdc-plugin/tests/minilitex_ddr_arty/minilitex_ddr_arty.tcl
@@ -1,8 +1,7 @@
 yosys -import
-plugin -i design_introspection
-plugin -i xdc
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_ports] == {} } { plugin -i design_introspection }
+if { [info procs read_xdc] == {} } { plugin -i xdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 read_verilog [file dirname [info script]]/VexRiscv_Lite.v

--- a/xdc-plugin/tests/package_pins/package_pins.tcl
+++ b/xdc-plugin/tests/package_pins/package_pins.tcl
@@ -1,8 +1,7 @@
 yosys -import
-plugin -i design_introspection
-plugin -i xdc
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_ports] == {} } { plugin -i design_introspection }
+if { [info procs read_xdc] == {} } { plugin -i xdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 # -flatten is used to ensure that the output eblif has only one module.

--- a/xdc-plugin/tests/port_indexes/port_indexes.tcl
+++ b/xdc-plugin/tests/port_indexes/port_indexes.tcl
@@ -1,8 +1,7 @@
 yosys -import
-plugin -i design_introspection
-plugin -i xdc
-#Import the commands from the plugins to the tcl interpreter
-yosys -import
+if { [info procs get_ports] == {} } { plugin -i design_introspection }
+if { [info procs read_xdc] == {} } { plugin -i xdc }
+yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 


### PR DESCRIPTION
In cases the plugins are compiled into yosys already, and no shared
objects with the plugins exist, the tests would otherwise fail.

This makes it possible to have the tests behave the same whether the
plugins are compiled in or not.