### PR TITLE
Make output path for test outputs configurable.

### DIFF
--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -17,6 +17,7 @@ CXX = $(shell yosys-config --cxx)
 CXXFLAGS = $(shell yosys-config --cxxflags) -I.. -I$(GTEST_DIR)/include
 LDLIBS = $(shell yosys-config --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
 LDFLAGS = $(shell yosys-config --ldflags)
+TEST_UTILS=../../../test-utils/test-utils.tcl
 
 define test_tpl =
 $(1): $(1)/ok
@@ -37,7 +38,8 @@ $(1)/ok: $(1)/$(1).v
 	@set +e; \
 	cd $(1); \
 	DESIGN_TOP=$(1) \
-	yosys -c $(1).tcl -q -l $(1).log; \
+	TEST_OUTPUT_PREFIX=./ \
+	yosys -c <(echo -e "source $(TEST_UTILS)\nsource $(1).tcl") -q -l $(1).log; \
 	RETVAL=$$$$?; \
 	if [ ! -z "$$($(1)_negative)" ] && [ $$($(1)_negative) -eq 1 ]; then \
 		if [ $$$$RETVAL -ne 0 ]; then \

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -37,7 +37,8 @@ $(1)/ok: $(1)/$(1).v
 	@echo "Running test $(1)"
 	@set +e; \
 	cd $(1); \
-	echo -e "source $(TEST_UTILS)\nsource $(1).tcl" > run-$(1).tcl ;\
+	echo "source $(TEST_UTILS)" > run-$(1).tcl ;\
+	echo "source $(1).tcl" >> run-$(1).tcl ;\
 	DESIGN_TOP=$(1) TEST_OUTPUT_PREFIX=./ \
 	yosys -c "run-$(1).tcl" -q -l $(1).log; \
 	RETVAL=$$$$?; \

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -37,10 +37,11 @@ $(1)/ok: $(1)/$(1).v
 	@echo "Running test $(1)"
 	@set +e; \
 	cd $(1); \
-	DESIGN_TOP=$(1) \
-	TEST_OUTPUT_PREFIX=./ \
-	yosys -c <(echo -e "source $(TEST_UTILS)\nsource $(1).tcl") -q -l $(1).log; \
+	echo -e "source $(TEST_UTILS)\nsource $(1).tcl" > run-$(1).tcl ;\
+	DESIGN_TOP=$(1) TEST_OUTPUT_PREFIX=./ \
+	yosys -c "run-$(1).tcl" -q -l $(1).log; \
 	RETVAL=$$$$?; \
+	rm -f run-$(1).tcl; \
 	if [ ! -z "$$($(1)_negative)" ] && [ $$($(1)_negative) -eq 1 ]; then \
 		if [ $$$$RETVAL -ne 0 ]; then \
 			echo "Negative test $(1) PASSED"; \

--- a/design_introspection-plugin/tests/get_cells/get_cells.tcl
+++ b/design_introspection-plugin/tests/get_cells/get_cells.tcl
@@ -7,7 +7,7 @@ read_verilog $::env(DESIGN_TOP).v
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 
 
-set fp [open "get_cells.txt" "w"]
+set fp [open [test_output_path "get_cells.txt"] "w"]
 
 puts "\n*inter* cells quiet"
 puts $fp "\n*inter* cells quiet"

--- a/design_introspection-plugin/tests/get_nets/get_nets.tcl
+++ b/design_introspection-plugin/tests/get_nets/get_nets.tcl
@@ -7,7 +7,7 @@ read_verilog $::env(DESIGN_TOP).v
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 
 
-set fp [open "get_nets.txt" "w"]
+set fp [open [test_output_path "get_nets.txt"] "w"]
 
 puts "\n*inter* nets quiet"
 puts $fp "*inter* nets quiet"

--- a/design_introspection-plugin/tests/get_pins/get_pins.tcl
+++ b/design_introspection-plugin/tests/get_pins/get_pins.tcl
@@ -7,7 +7,7 @@ read_verilog $::env(DESIGN_TOP).v
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 
 
-set fp [open "get_pins.txt" "w"]
+set fp [open [test_output_path "get_pins.txt"] "w"]
 
 puts "\n*inter* pins quiet"
 puts $fp "\n*inter* pins quiet"

--- a/design_introspection-plugin/tests/get_ports/get_ports.tcl
+++ b/design_introspection-plugin/tests/get_ports/get_ports.tcl
@@ -7,7 +7,7 @@ read_verilog $::env(DESIGN_TOP).v
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 help get_ports
 
-set fp [open "get_ports.txt" "w"]
+set fp [open [test_output_path "get_ports.txt"] "w"]
 
 puts "\n signal_p port"
 puts $fp "signal_p port"

--- a/params-plugin/tests/pll/pll.tcl
+++ b/params-plugin/tests/pll/pll.tcl
@@ -13,7 +13,7 @@ set phase [getparam CLKOUT2_PHASE top/PLLE2_ADV_0 top/PLLE2_ADV]
 if {[llength $phase] != 2} {
 	error "Getparam should return a list with 2 elements"
 }
-set fp [open "pll.txt" "w"]
+set fp [open [test_output_path "pll.txt"] "w"]
 puts -nonewline $fp "Phase before: "
 if {$phase == $reference_phase} {
 	puts $fp "PASS"
@@ -39,8 +39,8 @@ close $fp
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp -iopad -run prepare:check
 
 # Map Xilinx tech library to 7-series VPR tech library.
-read_verilog -lib ./techmaps/cells_sim.v
-techmap -map  ./techmaps/cells_map.v
+read_verilog -lib [file dirname $::env(DESIGN_TOP)]/techmaps/cells_sim.v
+techmap -map  [file dirname $::env(DESIGN_TOP)]/techmaps/cells_map.v
 
 # opt_expr -undriven makes sure all nets are driven, if only by the $undef
 # net.
@@ -51,5 +51,5 @@ setundef -zero -params
 stat
 
 # Write the design in JSON format.
-write_json $::env(DESIGN_TOP).json
-write_blif -attr -param -cname -conn pll.eblif
+write_json [test_output_path "pll.json"]
+write_blif -attr -param -cname -conn [test_output_path "pll.eblif"]

--- a/sdc-plugin/tests/counter/counter.tcl
+++ b/sdc-plugin/tests/counter/counter.tcl
@@ -16,11 +16,11 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write the clocks to file
-set fh [open $::env(DESIGN_TOP).txt w]
+set fh [open [test_output_path "counter.txt"] w]
 puts $fh [get_clocks]
 puts $fh [get_clocks -include_generated_clocks]
 close $fh
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
-write_json $::env(DESIGN_TOP).json
+write_sdc [test_output_path "counter.sdc"]
+write_json [test_output_path "counter.json"]

--- a/sdc-plugin/tests/counter2/counter2.tcl
+++ b/sdc-plugin/tests/counter2/counter2.tcl
@@ -16,10 +16,10 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write the clocks to file
-set fh [open $::env(DESIGN_TOP).txt w]
+set fh [open [test_output_path "counter2.txt"] w]
 set clocks [get_clocks]
 puts $fh $clocks
 close $fh
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "counter2.sdc"]

--- a/sdc-plugin/tests/get_clocks/get_clocks.tcl
+++ b/sdc-plugin/tests/get_clocks/get_clocks.tcl
@@ -18,7 +18,7 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write the clocks to file
-set fh [open $::env(DESIGN_TOP).txt w]
+set fh [open [test_output_path "get_clocks.txt"] w]
 
 puts $fh [get_clocks]
 

--- a/sdc-plugin/tests/period_check/period_check.tcl
+++ b/sdc-plugin/tests/period_check/period_check.tcl
@@ -13,4 +13,4 @@ synth_xilinx -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "period_check.sdc"]

--- a/sdc-plugin/tests/period_format_check/period_format_check.tcl
+++ b/sdc-plugin/tests/period_format_check/period_format_check.tcl
@@ -13,4 +13,4 @@ synth_xilinx -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "period_format_check.sdc"]

--- a/sdc-plugin/tests/pll/pll.tcl
+++ b/sdc-plugin/tests/pll/pll.tcl
@@ -17,4 +17,4 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "pll.sdc"]

--- a/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.tcl
+++ b/sdc-plugin/tests/pll_approx_equal/pll_approx_equal.tcl
@@ -17,4 +17,4 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "pll_approx_equal.sdc"]

--- a/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.tcl
+++ b/sdc-plugin/tests/pll_dangling_wires/pll_dangling_wires.tcl
@@ -17,4 +17,4 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "pll_dangling_wires.sdc"]

--- a/sdc-plugin/tests/pll_div/pll_div.tcl
+++ b/sdc-plugin/tests/pll_div/pll_div.tcl
@@ -17,4 +17,4 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "pll_div.sdc"]

--- a/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.tcl
+++ b/sdc-plugin/tests/pll_fbout_phase/pll_fbout_phase.tcl
@@ -17,4 +17,4 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "pll_fbout_phase.sdc"]

--- a/sdc-plugin/tests/pll_propagated/pll_propagated.tcl
+++ b/sdc-plugin/tests/pll_propagated/pll_propagated.tcl
@@ -17,4 +17,4 @@ read_sdc $::env(DESIGN_TOP).input.sdc
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc -include_propagated_clocks $::env(DESIGN_TOP).sdc
+write_sdc -include_propagated_clocks [test_output_path "pll_propagated.sdc"]

--- a/sdc-plugin/tests/restore_from_json/restore_from_json.tcl
+++ b/sdc-plugin/tests/restore_from_json/restore_from_json.tcl
@@ -6,9 +6,9 @@ read_verilog $::env(DESIGN_TOP).v
 synth_xilinx
 create_clock -period 10 clk
 propagate_clocks
-write_sdc $::env(DESIGN_TOP)_1.sdc
-write_json $::env(DESIGN_TOP).json
+write_sdc [test_output_path "restore_from_json_1.sdc"]
+write_json [test_output_path "restore_from_json.json"]
 
 design -push
-read_json $::env(DESIGN_TOP).json
-write_sdc $::env(DESIGN_TOP)_2.sdc
+read_json [test_output_path "restore_from_json.json"]
+write_sdc [test_output_path "restore_from_json_2.sdc"]

--- a/sdc-plugin/tests/set_clock_groups/set_clock_groups.tcl
+++ b/sdc-plugin/tests/set_clock_groups/set_clock_groups.tcl
@@ -12,4 +12,4 @@ set_clock_groups -group clk5 clk6 -logically_exclusive
 set_clock_groups -group clk7 clk8 -physically_exclusive -group clk9 clk10
 set_clock_groups -quiet -group clk11 clk12 -asynchronous -group clk13 clk14
 
-write_sdc set_clock_groups.sdc
+write_sdc [test_output_path "set_clock_groups.sdc"]

--- a/sdc-plugin/tests/set_false_path/set_false_path.tcl
+++ b/sdc-plugin/tests/set_false_path/set_false_path.tcl
@@ -18,4 +18,4 @@ set_false_path -from clk -to bottom_inst.I
 # -through bottom_inst/I
 set_false_path -through bottom_inst.I
 
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "set_false_path.sdc"]

--- a/sdc-plugin/tests/set_max_delay/set_max_delay.tcl
+++ b/sdc-plugin/tests/set_max_delay/set_max_delay.tcl
@@ -15,4 +15,4 @@ set_max_delay 2 -quiet -from clk
 # -from clk to bottom_inst/I
 set_max_delay 3 -from clk -to bottom_inst.I
 
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "set_max_delay.sdc"]

--- a/sdc-plugin/tests/waveform_check/waveform_check.tcl
+++ b/sdc-plugin/tests/waveform_check/waveform_check.tcl
@@ -13,4 +13,4 @@ synth_xilinx -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
 propagate_clocks
 
 # Write out the SDC file after the clock propagation step
-write_sdc $::env(DESIGN_TOP).sdc
+write_sdc [test_output_path "waveform_check.sdc"]

--- a/selection-plugin/tests/counter/counter.tcl
+++ b/selection-plugin/tests/counter/counter.tcl
@@ -3,7 +3,7 @@ if { [info procs selection_to_tcl_list] == {} } { plugin -i selection }
 yosys -import  ;# ingest plugin commands
 
 proc selection_to_tcl_list_through_file { selection } {
-    set file_name "[pid].txt"
+    set file_name [test_output_path "[pid].txt"]
     select $selection -write $file_name
     set fh [open $file_name r]
     set result [list]
@@ -31,7 +31,7 @@ read_verilog -lib +/xilinx/cells_xtra.v
 hierarchy -check -auto-top
 
 # Test the selection command and write results to file
-set rfh [open counter.txt w]
+set rfh [open [test_output_path "counter.txt"] w]
 
 set selection_tests [list "t:*" "w:*" "*"]
 foreach test $selection_tests {

--- a/test-utils/test-utils.tcl
+++ b/test-utils/test-utils.tcl
@@ -1,0 +1,7 @@
+# Utility functions to be used in tests.
+
+# Return path where the test output file "filename"
+# is to be written.
+proc test_output_path { filename } {
+    return "$::env(TEST_OUTPUT_PREFIX)${filename}"
+}

--- a/xdc-plugin/tests/counter/counter.tcl
+++ b/xdc-plugin/tests/counter/counter.tcl
@@ -10,7 +10,7 @@ read_verilog $::env(DESIGN_TOP).v
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 
 #Read the design constraints
-read_xdc -part_json ../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
+read_xdc -part_json [file dirname $::env(DESIGN_TOP)]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
 
 # Write the design in JSON format.
-write_json $::env(DESIGN_TOP).json
+write_json [test_output_path "counter.json"]

--- a/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.tcl
+++ b/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.tcl
@@ -10,7 +10,7 @@ read_verilog $::env(DESIGN_TOP).v
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 
 #Read the design constraints
-read_xdc -part_json ../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
+read_xdc -part_json [file dirname $::env(DESIGN_TOP)]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
 
 # Write the design in JSON format.
-write_json $::env(DESIGN_TOP).json
+write_json [test_output_path "io_loc_pairs.json"]

--- a/xdc-plugin/tests/minilitex_ddr_arty/minilitex_ddr_arty.tcl
+++ b/xdc-plugin/tests/minilitex_ddr_arty/minilitex_ddr_arty.tcl
@@ -10,7 +10,7 @@ read_verilog [file dirname [info script]]/VexRiscv_Lite.v
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 
 #Read the design constraints
-read_xdc -part_json ../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
+read_xdc -part_json [file dirname [info script]]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
 
 # Write the design in JSON format.
-write_json $::env(DESIGN_TOP).json
+write_json [test_output_path "minilitex_ddr_arty.json"]

--- a/xdc-plugin/tests/package_pins/package_pins.tcl
+++ b/xdc-plugin/tests/package_pins/package_pins.tcl
@@ -9,7 +9,7 @@ read_verilog $::env(DESIGN_TOP).v
 synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
 
 #Read the design constraints
-read_xdc -part_json ../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
+read_xdc -part_json [file dirname [info script]]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
 
 # Write the design in JSON format.
-write_json $::env(DESIGN_TOP).json
+write_json [test_output_path "package_pins.json"]

--- a/xdc-plugin/tests/port_indexes/port_indexes.tcl
+++ b/xdc-plugin/tests/port_indexes/port_indexes.tcl
@@ -13,7 +13,7 @@ if {[info procs unknown] != ""} {
 	rename unknown ""
 }
 proc unknown args {return "'unknown' proc command handler"}
-set fp [open "port_indexes.txt" "w"]
+set fp [open [test_output_path "port_indexes.txt"] "w"]
 if {[catch {invalid command} result]} {
 	close $fp
 	error "Command should be handled by the 'unknown' proc"
@@ -21,7 +21,7 @@ if {[catch {invalid command} result]} {
 	puts $fp $result
 }
 #Read the design constraints
-read_xdc -part_json ../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
+read_xdc -part_json [file dirname [info script]]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
 
 if {[catch {invalid command} result]} {
 	close $fp
@@ -32,4 +32,4 @@ if {[catch {invalid command} result]} {
 close $fp
 
 # Write the design in JSON format.
-write_json $::env(DESIGN_TOP).json
+write_json [test_output_path "port_indexes.json"]


### PR DESCRIPTION
In preparation for CI's and other test environments in which
the test outputs should be stored out-of-tree.

The new file test-utils.tcl provides a function that determines
the test output path (currently just by concatenating the filename
with a path from the environment). The Makefile_test.common sources
this utils file and the corresponding test file.

Since this adds a convenient test-utils.tcl file, this might also
be useful to put some testing boilerplate functionality there in
the future.

Signed-off-by: Henner Zeller <h.zeller@acm.org>