### PR TITLE
Add .editorconfig, to help contributors honor coding style.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# Editor config file, see http://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{h,cc,tcl}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Setting the indentation for tcl and cc to 4 characters which
is mostly what is happening in this repository. There are
a few tabs here and there, but they will vanish with changes
happening there

The .editorconfig file is supported by a vast number of IDEs and
editors, so hopefully this will make it simpler for would-be
contributors.

Signed-off-by: Henner Zeller <h.zeller@acm.org>