### PR TITLE
Fix incorrect behavior of QuickLogic qlf_k4n8 synthesis flow

### DIFF
--- a/ql-qlf-k4n8-plugin/synth_quicklogic.cc
+++ b/ql-qlf-k4n8-plugin/synth_quicklogic.cc
@@ -203,6 +203,7 @@ struct SynthQuickLogicPass : public ScriptPass {
             run("opt_merge");
             run("opt_clean");
             run("opt");
+            run("dfflegalize -cell $_DFF_P_ 0");
         }
 
         if (check_label("map_luts")) {

--- a/ql-qlf-k4n8-plugin/tests/Makefile
+++ b/ql-qlf-k4n8-plugin/tests/Makefile
@@ -1,6 +1,7 @@
+# The latch test is disabled as latches are not supported in the qlf_k4n8.
+
 TESTS = dffs \
 	iob_no_flatten \
-	latches \
 	soft_adder \
 	logic
 

--- a/ql-qlf-k4n8-plugin/tests/dffs/dffs.tcl
+++ b/ql-qlf-k4n8-plugin/tests/dffs/dffs.tcl
@@ -5,7 +5,7 @@ yosys -import  ;# ingest plugin commands
 read_verilog dffs.v
 design -save read
 
-# DFF
+# qlf_k4n8 supports only DFF w/o set and reset
 hierarchy -top my_dff
 yosys proc
 equiv_opt -assert -map +/quicklogic/qlf_k4n8_cells_sim.v synth_quicklogic -top my_dff
@@ -14,16 +14,3 @@ yosys cd my_dff
 stat
 select -assert-count 1 t:*_DFF_P_
 
-# DFFC
-design -load read
-synth_quicklogic -top my_dffc
-yosys cd my_dffc
-stat
-select -assert-count 1 t:*DFF_P*
-
-# DFFP
-design -load read
-synth_quicklogic -top my_dffp
-yosys cd my_dffp
-stat
-select -assert-count 1 t:*DFF_P*

--- a/ql-qlf-k4n8-plugin/tests/dffs/dffs.v
+++ b/ql-qlf-k4n8-plugin/tests/dffs/dffs.v
@@ -4,21 +4,3 @@ module my_dff ( input d, clk, output reg q );
         q <= d;
 endmodule
 
-module my_dffc ( input d, clk, clr, output reg q );
-    initial q <= 1'b0;
-    always @( posedge clk or posedge clr )
-        if ( clr )
-            q <= 1'b0;
-        else
-            q <= d;
-endmodule
-
-module my_dffp ( input d, clk, pre, output reg q );
-    initial q <= 1'b0;
-    always @( posedge clk or posedge pre )
-        if ( pre )
-            q <= 1'b1;
-        else
-            q <= d;
-endmodule
-


### PR DESCRIPTION
This PR fixes the issue of the flow inferring unsupported `$sdff` flip-flops by adding the `dfflegalize` pass.