### PR TITLE
Flip-flop reset support for QuickLogic qlf_k4n8

### DIFF
--- a/ql-qlf-k4n8-plugin/Makefile
+++ b/ql-qlf-k4n8-plugin/Makefile
@@ -2,7 +2,7 @@ NAME = ql-qlf-k4n8
 SOURCES = synth_quicklogic.cc
 include ../Makefile_plugin.common
 
-VERILOG_MODULES = cells_sim.v qlf_k4n8_arith_map.v qlf_k4n8_cells_sim.v
+VERILOG_MODULES = cells_sim.v qlf_k4n8_arith_map.v qlf_k4n8_cells_sim.v qlf_k4n8_ffs_map.v
 
 install_modules: $(VERILOG_MODULES)
 	$(foreach f,$^,install -D $(f) $(DATA_DIR)/quicklogic/$(f);)

--- a/ql-qlf-k4n8-plugin/qlf_k4n8_cells_sim.v
+++ b/ql-qlf-k4n8-plugin/qlf_k4n8_cells_sim.v
@@ -68,3 +68,67 @@ module scff(
     always @(posedge clk)
         Q <= D;
 endmodule
+
+(* abc9_flop, lib_whitebox *)
+module dff(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C)
+            Q <= D;
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module dffr(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C,
+    input R
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C or negedge R)
+        if (!R)
+            Q <= 1'b0;
+        else 
+            Q <= D;
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module sh_dff(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C)
+            Q <= D;
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module dffs(
+    output reg Q,
+    input D,
+    (* clkbuf_sink *)
+    input C,
+    input S
+);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+
+    always @(posedge C or negedge S)
+        if (!S)
+            Q <= 1'b1;
+        else
+            Q <= D;
+endmodule

--- a/ql-qlf-k4n8-plugin/qlf_k4n8_ffs_map.v
+++ b/ql-qlf-k4n8-plugin/qlf_k4n8_ffs_map.v
@@ -1,0 +1,80 @@
+module \$_DFF_P_ (D, Q, C);
+    input D;
+    input C;
+    output Q;
+    dff _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C));
+endmodule
+
+module \$_DFF_PN0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffr _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .R(R));
+endmodule
+
+module \$_DFF_PP0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffr _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .R(!R));
+endmodule
+
+module \$_DFF_PN1_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffs _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .S(R));
+endmodule
+
+module \$_DFF_PP1_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffs _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .S(!R));
+endmodule
+
+module \$__SHREG_DFF_P_ (D, Q, C);
+    input D;
+    input C;
+    output Q;
+
+    parameter DEPTH = 2;
+    reg [DEPTH-2:0] q;
+    //wire [DEPTH-1:0] d;
+    genvar i;
+    assign d[0] = D;
+    generate for (i = 0; i < DEPTH; i = i + 1) begin: slice
+
+
+        // First in chain
+        generate if (i == 0) begin
+                 sh_dff #() _TECHMAP_REPLACE_ (
+                    .Q(q[i]),
+                    .D(D),
+                    .C(C)
+                );
+        end endgenerate
+        // Middle in chain
+        generate if (i > 0 && i != DEPTH-1) begin
+                 sh_dff #() _TECHMAP_REPLACE_ (
+                    .Q(q[i]),
+                    .D(q[i-1]),
+                    .C(C)
+                );
+        end endgenerate
+        // Last in chain
+        generate if (i == DEPTH-1) begin
+                 sh_dff #() _TECHMAP_REPLACE_ (
+                    .Q(Q),
+                    .D(q[i-1]),
+                    .C(C)
+                );
+        end endgenerate
+   end: slice
+   endgenerate
+
+endmodule

--- a/ql-qlf-k4n8-plugin/synth_quicklogic.cc
+++ b/ql-qlf-k4n8-plugin/synth_quicklogic.cc
@@ -196,14 +196,18 @@ struct SynthQuickLogicPass : public ScriptPass {
         }
 
         if (check_label("map_ffs")) {
-
+            std::string techMapArgs = " -map +/quicklogic/" + family + "_ffs_map.v";
+            if (family == "qlf_k4n8") {
+                run("shregmap -minlen 8 -maxlen 8");
+            }
+            run("techmap " + techMapArgs);
             run("opt_expr -mux_undef");
             run("simplemap");
             run("opt_expr");
             run("opt_merge");
             run("opt_clean");
             run("opt");
-            run("dfflegalize -cell $_DFF_P_ 0");
+            run("dfflegalize -cell $_DFF_P_ x -cell $_DFF_P??_ x");
         }
 
         if (check_label("map_luts")) {

--- a/ql-qlf-k4n8-plugin/tests/Makefile
+++ b/ql-qlf-k4n8-plugin/tests/Makefile
@@ -1,6 +1,7 @@
 # The latch test is disabled as latches are not supported in the qlf_k4n8.
 
 TESTS = dffs \
+	shreg \
 	iob_no_flatten \
 	soft_adder \
 	logic
@@ -8,6 +9,7 @@ TESTS = dffs \
 include $(shell pwd)/../../Makefile_test.common
 
 dffs_verify = true
+shreg_verify = true
 iob_no_flatten_verify = true
 latches_verify = true
 soft_adder_verify = true

--- a/ql-qlf-k4n8-plugin/tests/dffs/dffs.tcl
+++ b/ql-qlf-k4n8-plugin/tests/dffs/dffs.tcl
@@ -5,12 +5,41 @@ yosys -import  ;# ingest plugin commands
 read_verilog dffs.v
 design -save read
 
-# qlf_k4n8 supports only DFF w/o set and reset
+# DFF
 hierarchy -top my_dff
 yosys proc
 equiv_opt -assert -map +/quicklogic/qlf_k4n8_cells_sim.v synth_quicklogic -top my_dff
 design -load postopt
 yosys cd my_dff
 stat
-select -assert-count 1 t:*_DFF_P_
+select -assert-count 1 t:dff
 
+# DFFR (posedge RST)
+design -load read
+synth_quicklogic -top my_dffr_p
+yosys cd my_dffr_p
+stat
+select -assert-count 1 t:dffr
+select -assert-count 1 t:\$lut
+
+# DFFR (negedge RST)
+design -load read
+synth_quicklogic -top my_dffr_n
+yosys cd my_dffr_n
+stat
+select -assert-count 1 t:dffr
+
+# DFFS (posedge SET)
+design -load read
+synth_quicklogic -top my_dffs_p
+yosys cd my_dffs_p
+stat
+select -assert-count 1 t:dffs
+select -assert-count 1 t:\$lut
+
+# DFFS (negedge SET)
+design -load read
+synth_quicklogic -top my_dffs_n
+yosys cd my_dffs_n
+stat
+select -assert-count 1 t:dffs

--- a/ql-qlf-k4n8-plugin/tests/dffs/dffs.v
+++ b/ql-qlf-k4n8-plugin/tests/dffs/dffs.v
@@ -4,3 +4,39 @@ module my_dff ( input d, clk, output reg q );
         q <= d;
 endmodule
 
+module my_dffr_p ( input d, clk, clr, output reg q );
+    initial q <= 1'b0;
+    always @( posedge clk or posedge clr )
+        if ( clr )
+            q <= 1'b0;
+        else
+            q <= d;
+endmodule
+
+module my_dffr_n ( input d, clk, clr, output reg q );
+    initial q <= 1'b0;
+    always @( posedge clk or negedge clr )
+        if ( !clr )
+            q <= 1'b0;
+        else
+            q <= d;
+endmodule
+
+module my_dffs_p ( input d, clk, pre, output reg q );
+    initial q <= 1'b0;
+    always @( posedge clk or posedge pre )
+        if ( pre )
+            q <= 1'b1;
+        else
+            q <= d;
+endmodule
+
+module my_dffs_n ( input d, clk, pre, output reg q );
+    initial q <= 1'b0;
+    always @( posedge clk or negedge pre )
+        if ( !pre )
+            q <= 1'b1;
+        else
+            q <= d;
+endmodule
+

--- a/ql-qlf-k4n8-plugin/tests/iob_no_flatten/iob_no_flatten.tcl
+++ b/ql-qlf-k4n8-plugin/tests/iob_no_flatten/iob_no_flatten.tcl
@@ -7,4 +7,4 @@ read_verilog iob_no_flatten.v
 synth_quicklogic -top my_top
 yosys stat
 yosys cd my_top
-select -assert-count 2 t:\$_DFF_P_
+select -assert-count 2 t:dff

--- a/ql-qlf-k4n8-plugin/tests/shreg/shreg.tcl
+++ b/ql-qlf-k4n8-plugin/tests/shreg/shreg.tcl
@@ -1,0 +1,8 @@
+yosys -import
+if { [info procs ql-qlf-k4n8] == {} } { plugin -i ql-qlf-k4n8 }
+yosys -import ;# ingest plugin commands
+
+read_verilog shreg.v
+synth_quicklogic -top top
+stat
+select -assert-count 8 t:sh_dff

--- a/ql-qlf-k4n8-plugin/tests/shreg/shreg.v
+++ b/ql-qlf-k4n8-plugin/tests/shreg/shreg.v
@@ -1,0 +1,14 @@
+module top (
+    input  wire I,
+    input  wire C,
+    output wire O
+);
+
+    reg [7:0] shift_register;
+
+    always @(posedge C)
+        shift_register <= {shift_register[6:0], I};
+
+    assign O = shift_register[7];
+
+endmodule


### PR DESCRIPTION
This PR adds support for local flip-flop resets for the QuickLogic qlf_k4n8 architecture. It also adds an additional flip-flop type for a shift register as well as shift register inference. Tests have been updated accordingly.