### PR TITLE
xdc: allow GTPE2_CHANNEL to have IO_LOC_PAIRS

### DIFF
--- a/xdc-plugin/tests/compare_output_json.py
+++ b/xdc-plugin/tests/compare_output_json.py
@@ -10,7 +10,7 @@ import sys
 import json
 import argparse
 
-parameters = ["IOSTANDARD", "DRIVE", "SLEW", "IN_TERM"]
+parameters = ["IOSTANDARD", "DRIVE", "SLEW", "IN_TERM", "IO_LOC_PAIRS"]
 
 def read_cells(json_file):
     with open(json_file) as f:

--- a/xdc-plugin/tests/io_loc_pairs/cells_xtra.v
+++ b/xdc-plugin/tests/io_loc_pairs/cells_xtra.v
@@ -1,0 +1,12 @@
+module GTPE2_CHANNEL (
+    (* iopad_external_pin *)
+    output GTPTXN,
+    (* iopad_external_pin *)
+    output GTPTXP,
+    (* iopad_external_pin *)
+    input GTPRXN,
+    (* iopad_external_pin *)
+    input GTPRXP
+);
+
+endmodule

--- a/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.golden.json
+++ b/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.golden.json
@@ -1,47 +1,53 @@
 {
-  "OBUFTDS_2": {
-    "IOSTANDARD": "DIFF_SSTL135",
-    "IO_LOC_PAIRS": "signal_p:N2,signal_n:N1",
-    "SLEW": "FAST"
-  },
-  "OBUF_6": {
-    "DRIVE": "12",
-    "IOSTANDARD": "LVCMOS33",
-    "IO_LOC_PAIRS": "led[0]:D10",
-    "SLEW": "SLOW"
-  },
-  "OBUF_7": {
-    "IN_TERM": "UNTUNED_SPLIT_40",
-    "IOSTANDARD": "SSTL135",
-    "IO_LOC_PAIRS": "led[1]:A9",
-    "SLEW": "FAST"
-  },
-  "OBUF_OUT": {
-    "IN_TERM": "UNTUNED_SPLIT_50",
-    "IOSTANDARD": "LVCMOS33",
-    "IO_LOC_PAIRS": "out_a:E3",
-    "SLEW": "FAST"
-  },
-  "bottom_inst.OBUF_10": {
-    "IOSTANDARD": "LVCMOS18",
-    "IO_LOC_PAIRS": "out_b[0]:C2",
-    "SLEW": "SLOW"
-  },
-  "bottom_inst.OBUF_11": {
-    "DRIVE": "4",
-    "IOSTANDARD": "LVCMOS25",
-    "IO_LOC_PAIRS": "out_b[1]:R2",
-    "SLEW": "FAST"
-  },
-  "bottom_inst.OBUF_9": {
-    "IOSTANDARD": "DIFF_SSTL135",
-    "IO_LOC_PAIRS": "led[2]:M6",
-    "SLEW": "FAST"
-  },
-  "bottom_intermediate_inst.OBUF_8": {
-    "DRIVE": "16",
-    "IOSTANDARD": "SSTL135",
-    "IO_LOC_PAIRS": "led[3]:N4",
-    "SLEW": "SLOW"
-  }
+    "GTPE2_CHANNEL": {
+        "IO_LOC_PAIRS": "rx_p:G1,rx_n:G2,tx_p:G3,tx_n:G4"
+    },
+    "IBUFDS_GTE2": {
+        "IO_LOC_PAIRS": "ibufds_gte2_i:G5,ibufds_gte2_ib:G6"
+    },
+    "OBUFTDS_2": {
+        "IOSTANDARD": "DIFF_SSTL135",
+        "IO_LOC_PAIRS": "signal_p:N2,signal_n:N1",
+        "SLEW": "FAST"
+    },
+    "OBUF_6": {
+        "DRIVE": "12",
+        "IOSTANDARD": "LVCMOS33",
+        "IO_LOC_PAIRS": "led[0]:D10",
+        "SLEW": "SLOW"
+    },
+    "OBUF_7": {
+        "IN_TERM": "UNTUNED_SPLIT_40",
+        "IOSTANDARD": "SSTL135",
+        "IO_LOC_PAIRS": "led[1]:A9",
+        "SLEW": "FAST"
+    },
+    "OBUF_OUT": {
+        "IN_TERM": "UNTUNED_SPLIT_50",
+        "IOSTANDARD": "LVCMOS33",
+        "IO_LOC_PAIRS": "out_a:E3",
+        "SLEW": "FAST"
+    },
+    "bottom_inst.OBUF_10": {
+        "IOSTANDARD": "LVCMOS18",
+        "IO_LOC_PAIRS": "out_b[0]:C2",
+        "SLEW": "SLOW"
+    },
+    "bottom_inst.OBUF_11": {
+        "DRIVE": "4",
+        "IOSTANDARD": "LVCMOS25",
+        "IO_LOC_PAIRS": "out_b[1]:R2",
+        "SLEW": "FAST"
+    },
+    "bottom_inst.OBUF_9": {
+        "IOSTANDARD": "DIFF_SSTL135",
+        "IO_LOC_PAIRS": "led[2]:M6",
+        "SLEW": "FAST"
+    },
+    "bottom_intermediate_inst.OBUF_8": {
+        "DRIVE": "16",
+        "IOSTANDARD": "SSTL135",
+        "IO_LOC_PAIRS": "led[3]:N4",
+        "SLEW": "SLOW"
+    }
 }

--- a/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.tcl
+++ b/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.tcl
@@ -5,12 +5,19 @@ yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 
+read_verilog -lib -specify +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+read_verilog -lib cells_xtra.v
+
+hierarchy -check -top top
+
 # -flatten is used to ensure that the output eblif has only one module.
 # Some of symbiflow expects eblifs with only one module.
-synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
+synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp -run prepare:check
 
 #Read the design constraints
 read_xdc -part_json [file dirname $::env(DESIGN_TOP)]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
 
 # Write the design in JSON format.
 write_json [test_output_path "io_loc_pairs.json"]
+write_blif -param [test_output_path "io_loc_pairs.eblif"]

--- a/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.v
+++ b/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.v
@@ -4,7 +4,13 @@ module top (
     inout out_a,
     output [1:0] out_b,
     output signal_p,
-    output signal_n
+    output signal_n,
+    input rx_n,
+    input rx_p,
+    output tx_n,
+    output tx_p,
+    input ibufds_gte2_i,
+    input ibufds_gte2_ib
 );
 
   wire LD6, LD7, LD8, LD9;
@@ -20,12 +26,14 @@ module top (
   assign led[1] = inter_wire;
   assign inter_wire = inter_wire_2;
   assign {LD9, LD8, LD7, LD6} = counter >> LOG2DELAY;
+
   OBUFTDS OBUFTDS_2 (
       .I (LD6),
       .O (signal_p),
       .OB(signal_n),
       .T (1'b1)
   );
+
   OBUF #(
       .IOSTANDARD("LVCMOS33"),
       .SLEW("SLOW")
@@ -33,6 +41,7 @@ module top (
       .I(LD6),
       .O(led[0])
   );
+
   OBUF #(
       .IOSTANDARD("LVCMOS33"),
       .SLEW("SLOW")
@@ -40,6 +49,7 @@ module top (
       .I(LD7),
       .O(inter_wire_2)
   );
+
   OBUF #(
       .IOSTANDARD("LVCMOS33"),
       .SLEW("SLOW")
@@ -47,14 +57,29 @@ module top (
       .I(LD7),
       .O(out_a)
   );
+
   bottom bottom_inst (
       .I (LD8),
       .O (led[2]),
       .OB(out_b)
   );
+
   bottom_intermediate bottom_intermediate_inst (
       .I(LD9),
       .O(led[3])
+  );
+
+  GTPE2_CHANNEL GTPE2_CHANNEL(
+    .GTPRXP(rx_p),
+    .GTPRXN(rx_n),
+    .GTPTXP(tx_p),
+    .GTPTXN(tx_n)
+  );
+
+  (* keep *)
+  IBUFDS_GTE2 IBUFDS_GTE2(
+    .I(ibufds_gte2_i),
+    .IB(ibufds_gte2_ib)
   );
 endmodule
 
@@ -62,8 +87,10 @@ module bottom_intermediate (
     input  I,
     output O
 );
-  wire bottom_intermediate_wire;
+
+wire bottom_intermediate_wire;
   assign O = bottom_intermediate_wire;
+
   OBUF #(
       .IOSTANDARD("LVCMOS33"),
       .SLEW("SLOW")
@@ -78,6 +105,7 @@ module bottom (
     output [1:0] OB,
     output O
 );
+
   OBUF #(
       .IOSTANDARD("LVCMOS33"),
       .SLEW("SLOW")
@@ -85,6 +113,7 @@ module bottom (
       .I(I),
       .O(O)
   );
+
   OBUF #(
       .IOSTANDARD("LVCMOS33"),
       .SLEW("SLOW")
@@ -92,6 +121,7 @@ module bottom (
       .I(I),
       .O(OB[0])
   );
+
   OBUF #(
       .IOSTANDARD("LVCMOS33"),
       .SLEW("SLOW")
@@ -100,4 +130,3 @@ module bottom (
       .O(OB[1])
   );
 endmodule
-

--- a/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.xdc
+++ b/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.xdc
@@ -1,36 +1,52 @@
-#OBUF_6
+# OBUF_6
 set_property LOC D10 [get_ports {led[0]}]
 set_property DRIVE 12 [get_ports {led[0]}]
-#OBUF_7
+
+# OBUF_7
 set_property LOC A9 [get_ports {led[1]}]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports led[1]]
 set_property SLEW FAST [get_ports led[1]]
 set_property IOSTANDARD SSTL135 [get_ports led[1]]
-#OBUF_OUT
+
+# OBUF_OUT
 set_property LOC E3 [get_ports out_a]
 set_property IN_TERM UNTUNED_SPLIT_50 [get_ports out_a]
 set_property SLEW FAST [get_ports out_a]
 set_property IOSTANDARD LVCMOS33 [get_ports out_a]
-#bottom_inst.OBUF_10
+
+# bottom_inst.OBUF_10
 set_property LOC C2 [get_ports {out_b[0]}]
 set_property SLEW SLOW [get_ports {out_b[0]}]
 set_property IOSTANDARD LVCMOS18 [get_ports {out_b[0]}]
-#bottom_inst.OBUF_11
+
+# bottom_inst.OBUF_11
 set_property LOC R2 [get_ports {out_b[1]}]
 set_property DRIVE 4 [get_ports {out_b[1]}]
 set_property SLEW FAST [get_ports {out_b[1]}]
 set_property IOSTANDARD LVCMOS25 [get_ports {out_b[1]}]
-#bottom_inst.OBUF_9
+
+# bottom_inst.OBUF_9
 set_property LOC M6 [get_ports {led[2]}]
 set_property SLEW FAST [get_ports {led[2]}]
 set_property IOSTANDARD DIFF_SSTL135 [get_ports {led[2]}]
-#bottom_intermediate_inst.OBUF_8
+
+# bottom_intermediate_inst.OBUF_8
 set_property LOC N4 [get_ports {led[3]}]
 set_property DRIVE 16 [get_ports {led[3]}]
 set_property IOSTANDARD SSTL135 [get_ports {led[3]}]
-#OBUFTDS_2
+
+# OBUFTDS_2
 set_property LOC N2 [get_ports signal_p]
 set_property LOC N1 [get_ports signal_n]
 set_property SLEW FAST [get_ports signal_p]
 set_property IOSTANDARD DIFF_SSTL135 [get_ports signal_p]
 
+# GTPE2_CHANNEL
+set_property LOC G1 [get_ports {rx_p}]
+set_property LOC G2 [get_ports {rx_n}]
+set_property LOC G3 [get_ports {tx_p}]
+set_property LOC G4 [get_ports {tx_n}]
+
+# IBUFDS_GTE2
+set_property LOC G5 [get_ports {ibufds_gte2_i}]
+set_property LOC G6 [get_ports {ibufds_gte2_ib}]

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -57,7 +57,8 @@ const std::unordered_map<std::string, std::vector<std::string>> supported_primit
   {"IBUF", {"IO_LOC_PAIRS", "IOSTANDARD"}},
   {"IOBUF", {"IO_LOC_PAIRS", "IOSTANDARD", "DRIVE", "SLEW", "IN_TERM"}},
   {"IOBUFDS", {"IO_LOC_PAIRS", "IOSTANDARD", "SLEW", "IN_TERM"}},
-  {"IBUFDS_GTE2", {"IO_LOC_PAIRS"}}};
+  {"IBUFDS_GTE2", {"IO_LOC_PAIRS"}},
+  {"GTPE2_CHANNEL", {"IO_LOC_PAIRS"}}};
 
 void register_in_tcl_interpreter(const std::string &command)
 {

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -50,6 +50,10 @@ const std::unordered_map<std::string, SetPropertyOptions> set_property_options_m
                                                                                       {"LOC", SetPropertyOptions::IO_LOC_PAIRS},
                                                                                       {"PACKAGE_PIN", SetPropertyOptions::IO_LOC_PAIRS}};
 
+// Apart from the common I/OBUFs there is also the GTPE2_CHANNEL primitive which has a total
+// of four IOPADs (2 IPADs and 2 OPADs) which are directly connected to the GTP[RT]X[PN] ports
+// of the BEL. The GTPE2_CHANNEL holds all the placement constraints information of the
+// corresponding PADs
 const std::unordered_map<std::string, std::vector<std::string>> supported_primitive_parameters = {
   {"OBUF", {"IO_LOC_PAIRS", "IOSTANDARD", "DRIVE", "SLEW", "IN_TERM"}},
   {"OBUFDS", {"IO_LOC_PAIRS", "IOSTANDARD", "SLEW", "IN_TERM"}},


### PR DESCRIPTION
The GTPE2_CHANNEL does not have intermediate buffers to the IOPADs. Therefore, it is necessary to allow it to have IO_LOC_PAIRS attributes to generate correct placement constraints based on the IO signals locations.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>