### PR TITLE
Reduce visual noise when running tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean_$(1):
 	$$(MAKE) -C $(1)-plugin clean
 
 test_$(1):
-	$$(MAKE) -C $(1)-plugin test
+	@$$(MAKE) --no-print-directory -C $(1)-plugin test
 endef
 
 $(foreach plugin,$(PLUGIN_LIST),$(eval $(call install_plugin,$(plugin))))

--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -1,3 +1,4 @@
+# -*- Makefile -*-
 # This Makefile template is supposed to be included in each plugin's Makefile.
 # Plugin Makefiles need to specify the plugin's name and source files.
 # The plugin name is how the final shared object will be named.
@@ -52,7 +53,7 @@ install_plugin: $(NAME).so
 	install -D $< $(PLUGINS_DIR)/$<
 
 test:
-	$(MAKE) -C tests all
+	@$(MAKE) -C tests all
 
 .PHONY: install
 install: install_plugin

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -29,7 +29,7 @@ $(1): $(1)/ok
 		touch $$<; \
 		true; \
 	else \
-		printf "Test %-18s \e[30;1mFAILED\e[0m @ %s\n" $(1) $(CURIDR); \
+		printf "Test %-18s \e[31;1mFAILED\e[0m @ %s\n" $(1) $(CURDIR); \
 		false; \
 	fi
 
@@ -47,7 +47,7 @@ $(1)/ok: $(1)/$(1).v
 			printf "Negative test %-18s \e[32mPASSED\e[0m @ %s\n" $(1) $(CURDIR); \
 			true; \
 		else \
-			printf "Negative test %-18s \e[30;1mFAILED\e[0m @ %s\n" $(1) $(CURIDR); \
+			printf "Negative test %-18s \e[31;1mFAILED\e[0m @ %s\n" $(1) $(CURDIR); \
 			false; \
 		fi \
 	else \

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -22,34 +22,32 @@ TEST_UTILS=../../../test-utils/test-utils.tcl
 
 define test_tpl =
 $(1): $(1)/ok
-	@echo "Verifying result of test $(1)"
 	@set +e; \
 	$$($(1)_verify); \
 	if [ $$$$? -eq 0 ]; then \
-		echo "Test $(1) PASSED"; \
+		printf "Test %-18s \e[32mPASSED\e[0m @ %s\n" $(1) $(CURDIR); \
 		touch $$<; \
 		true; \
 	else \
-		echo "Test $(1) FAILED"; \
+		printf "Test %-18s \e[30;1mFAILED\e[0m @ %s\n" $(1) $(CURIDR); \
 		false; \
 	fi
 
 $(1)/ok: $(1)/$(1).v
-	@echo "Running test $(1)"
 	@set +e; \
 	cd $(1); \
 	echo "source $(TEST_UTILS)" > run-$(1).tcl ;\
 	echo "source $(1).tcl" >> run-$(1).tcl ;\
 	DESIGN_TOP=$(1) TEST_OUTPUT_PREFIX=./ \
-	yosys -c "run-$(1).tcl" -q -l $(1).log; \
+	yosys -c "run-$(1).tcl" -q -q -l $(1).log; \
 	RETVAL=$$$$?; \
 	rm -f run-$(1).tcl; \
 	if [ ! -z "$$($(1)_negative)" ] && [ $$($(1)_negative) -eq 1 ]; then \
 		if [ $$$$RETVAL -ne 0 ]; then \
-			echo "Negative test $(1) PASSED"; \
+			printf "Negative test %-18s \e[32mPASSED\e[0m @ %s\n" $(1) $(CURDIR); \
 			true; \
 		else \
-			echo "Negative test $(1) FAILED"; \
+			printf "Negative test %-18s \e[30;1mFAILED\e[0m @ %s\n" $(1) $(CURIDR); \
 			false; \
 		fi \
 	else \

--- a/ql-iob-plugin/tests/Makefile
+++ b/ql-iob-plugin/tests/Makefile
@@ -6,8 +6,8 @@ clean:
 	@find . -name "ok" | xargs rm -rf
 
 sdiomux/ok:
-	cd sdiomux && $(MAKE) test
+	@$(MAKE) -C sdiomux test
 ckpad/ok:
-	cd ckpad && $(MAKE) test
+	@$(MAKE) -C ckpad test
 
 .PHONY: all clean

--- a/ql-iob-plugin/tests/ckpad/Makefile
+++ b/ql-iob-plugin/tests/ckpad/Makefile
@@ -1,5 +1,5 @@
 # TODO: Integrate this in the Makefile_test.command environment ?
 test:
-	yosys -s script.ys -q -q -l $@.log
+	@yosys -s script.ys -q -q -l $@.log
 	@printf "Test %-18s \e[32mPASSED\e[0m @ %s\n" $@ $(CURDIR);
 	@touch ok

--- a/ql-iob-plugin/tests/ckpad/Makefile
+++ b/ql-iob-plugin/tests/ckpad/Makefile
@@ -1,4 +1,5 @@
+# TODO: Integrate this in the Makefile_test.command environment ?
 test:
-	yosys -s script.ys
-	@echo $@ PASS
+	yosys -s script.ys -q -q -l $@.log
+	@printf "Test %-18s \e[32mPASSED\e[0m @ %s\n" $@ $(CURDIR);
 	@touch ok

--- a/ql-iob-plugin/tests/sdiomux/Makefile
+++ b/ql-iob-plugin/tests/sdiomux/Makefile
@@ -1,5 +1,5 @@
 # TODO: Integrate this in the Makefile_test.command environment ?
 test:
-	yosys -s script.ys -q -q -l $@.log
+	@yosys -s script.ys -q -q -l $@.log
 	@printf "Test %-18s \e[32mPASSED\e[0m @ %s\n" $@ $(CURDIR);
 	@touch ok

--- a/ql-iob-plugin/tests/sdiomux/Makefile
+++ b/ql-iob-plugin/tests/sdiomux/Makefile
@@ -1,4 +1,5 @@
+# TODO: Integrate this in the Makefile_test.command environment ?
 test:
-	yosys -s script.ys
-	@echo $@ PASS
+	yosys -s script.ys -q -q -l $@.log
+	@printf "Test %-18s \e[32mPASSED\e[0m @ %s\n" $@ $(CURDIR);
 	@touch ok


### PR DESCRIPTION
Don't clutter the output with entering/leaving directory messages or spurious warnings from tools. Have one line output per test if possible.

Warnings and other yosys logs end up in the test-specific logfile.

The test results are clearly marked and highlighted as passing/failing.

Signed-off-by: Henner Zeller <h.zeller@acm.org>