### PR TITLE
Fix loading of ql-qlf-k4n8 plugin in tests; use canonical test.v name

### DIFF
--- a/ql-qlf-k4n8-plugin/tests/dffs/dffs.tcl
+++ b/ql-qlf-k4n8-plugin/tests/dffs/dffs.tcl
@@ -1,8 +1,8 @@
 yosys -import
-if { [info procs ql-qlf-k4n8] == {} } { plugin -i ql-qlf-k4n8 }
+if { [info procs synth_quicklogic] == {} } { plugin -i ql-qlf-k4n8 }
 yosys -import  ;# ingest plugin commands
 
-read_verilog dffs.v
+read_verilog $::env(DESIGN_TOP).v
 design -save read
 
 # DFF

--- a/ql-qlf-k4n8-plugin/tests/iob_no_flatten/iob_no_flatten.tcl
+++ b/ql-qlf-k4n8-plugin/tests/iob_no_flatten/iob_no_flatten.tcl
@@ -1,8 +1,8 @@
 yosys -import
-if { [info procs ql-qlf-k4n8] == {} } { plugin -i ql-qlf-k4n8 }
+if { [info procs synth_quicklogic] == {} } { plugin -i ql-qlf-k4n8 }
 yosys -import  ;# ingest plugin commands
 
-read_verilog iob_no_flatten.v
+read_verilog $::env(DESIGN_TOP).v
 
 synth_quicklogic -top my_top
 yosys stat

--- a/ql-qlf-k4n8-plugin/tests/latches/latches.tcl
+++ b/ql-qlf-k4n8-plugin/tests/latches/latches.tcl
@@ -1,8 +1,8 @@
 yosys -import
-if { [info procs ql-qlf-k4n8] == {} } { plugin -i ql-qlf-k4n8 }
+if { [info procs synth_quicklogic] == {} } { plugin -i ql-qlf-k4n8 }
 yosys -import  ;# ingest plugin commands
 
-read_verilog latches.v
+read_verilog $::env(DESIGN_TOP).v
 design -save read
 
 # LATCHP
@@ -17,4 +17,3 @@ synth_quicklogic -top latchn
 yosys cd latchn
 stat
 select -assert-count 1 t:\$_DLATCH_N_
-

--- a/ql-qlf-k4n8-plugin/tests/logic/logic.tcl
+++ b/ql-qlf-k4n8-plugin/tests/logic/logic.tcl
@@ -1,8 +1,8 @@
 yosys -import
-if { [info procs ql-qlf-k4n8] == {} } { plugin -i ql-qlf-k4n8 }
+if { [info procs synth_quicklogic] == {} } { plugin -i ql-qlf-k4n8 }
 yosys -import  ;# ingest plugin commands
 
-read_verilog logic.v
+read_verilog $::env(DESIGN_TOP).v
 hierarchy -top top
 yosys proc
 equiv_opt -assert -map +/quicklogic/qlf_k4n8_cells_sim.v synth_quicklogic

--- a/ql-qlf-k4n8-plugin/tests/shreg/shreg.tcl
+++ b/ql-qlf-k4n8-plugin/tests/shreg/shreg.tcl
@@ -1,8 +1,8 @@
 yosys -import
-if { [info procs ql-qlf-k4n8] == {} } { plugin -i ql-qlf-k4n8 }
+if { [info procs synth_quicklogic] == {} } { plugin -i ql-qlf-k4n8 }
 yosys -import ;# ingest plugin commands
 
-read_verilog shreg.v
+read_verilog $::env(DESIGN_TOP).v
 synth_quicklogic -top top
 stat
 select -assert-count 8 t:sh_dff

--- a/ql-qlf-k4n8-plugin/tests/soft_adder/soft_adder.tcl
+++ b/ql-qlf-k4n8-plugin/tests/soft_adder/soft_adder.tcl
@@ -1,9 +1,9 @@
 yosys -import
-if { [info procs ql-qlf-k4n8] == {} } { plugin -i ql-qlf-k4n8 }
+if { [info procs synth_quicklogic] == {} } { plugin -i ql-qlf-k4n8 }
 yosys -import  ;# ingest plugin commands
 
 # Equivalence check for adder synthesis
-read_verilog -icells -DWIDTH=4 soft_adder.v
+read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top adder
 yosys proc
 equiv_opt -assert -map +/quicklogic/qlf_k4n8_cells_sim.v synth_quicklogic -family qlf_k4n8
@@ -11,7 +11,7 @@ equiv_opt -assert -map +/quicklogic/qlf_k4n8_cells_sim.v synth_quicklogic -famil
 design -reset
 
 # Equivalence check for subtractor synthesis
-read_verilog -icells -DWIDTH=4 soft_adder.v
+read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top subtractor
 yosys proc
 equiv_opt -assert  -map +/quicklogic/qlf_k4n8_cells_sim.v synth_quicklogic -family qlf_k4n8


### PR DESCRIPTION
The line that is loading the plug-in is meant to skip attempting
loading a plugin with a particular name if the symbol we're interested
in is already there.

So in the ql-qlf-k4n8 case, we have to test for synth_quicklogic:

```diff
-if { [info procs ql-qlf-k4n8] == {} } { plugin -i ql-qlf-k4n8 }
+if { [info procs synth_quicklogic] == {} } { plugin -i ql-qlf-k4n8 }
```

(reason for all that: this allows to statically link the plugins
and have these scripts work idempotently).

For loading the test-related *.v files: use `$::env(DESIGN_TOP).v`
instead of the direct name. That allows it to run independently
from where the tests are invoked, as the test-driver can set the
environment variable to the fully qualified path.

Signed-off-by: Henner Zeller <h.zeller@acm.org>