### PR TITLE
Fix for incorrect 'techmap' and 'dfflegalize' pass ordering

### DIFF
--- a/ql-qlf-k4n8-plugin/qlf_k4n8_ffs_map.v
+++ b/ql-qlf-k4n8-plugin/qlf_k4n8_ffs_map.v
@@ -89,7 +89,7 @@ module \$__SHREG_DFF_P_ (D, Q, C);
 
         // First in chain
         generate if (i == 0) begin
-                 sh_dff #() _TECHMAP_REPLACE_ (
+                 sh_dff #() shreg_beg (
                     .Q(q[i]),
                     .D(D),
                     .C(C)
@@ -97,7 +97,7 @@ module \$__SHREG_DFF_P_ (D, Q, C);
         end endgenerate
         // Middle in chain
         generate if (i > 0 && i != DEPTH-1) begin
-                 sh_dff #() _TECHMAP_REPLACE_ (
+                 sh_dff #() shreg_mid (
                     .Q(q[i]),
                     .D(q[i-1]),
                     .C(C)
@@ -105,7 +105,7 @@ module \$__SHREG_DFF_P_ (D, Q, C);
         end endgenerate
         // Last in chain
         generate if (i == DEPTH-1) begin
-                 sh_dff #() _TECHMAP_REPLACE_ (
+                 sh_dff #() shreg_end (
                     .Q(Q),
                     .D(q[i-1]),
                     .C(C)

--- a/ql-qlf-k4n8-plugin/synth_quicklogic.cc
+++ b/ql-qlf-k4n8-plugin/synth_quicklogic.cc
@@ -205,20 +205,20 @@ struct SynthQuickLogicPass : public ScriptPass {
         }
 
         if (check_label("map_ffs")) {
-            std::string techMapArgs = " -map +/quicklogic/" + family + "_ffs_map.v";
             if (family == "qlf_k4n8") {
                 run("shregmap -minlen 8 -maxlen 8");
             }
-            if (!noffmap) {
-                run("techmap " + techMapArgs);
-            }
             run("opt_expr -mux_undef");
-            run("simplemap");
-            run("opt_expr");
             run("opt_merge");
             run("opt_clean");
             run("opt");
-            run("dfflegalize -cell $_DFF_P_ x -cell $_DFF_P??_ x -cell $_DFF_N_ x -cell $_DFF_N??_ x");
+            run("dfflegalize -cell $_DFF_P_ 0 -cell $_DFF_P??_ 0 -cell $_DFF_N_ 0 -cell $_DFF_N??_ 0");
+
+            std::string techMapArgs = " -map +/techmap.v";
+            if (!noffmap) {
+                techMapArgs += " -map +/quicklogic/" + family + "_ffs_map.v";
+            }
+            run("techmap " + techMapArgs);
         }
 
         if (check_label("map_luts")) {

--- a/ql-qlf-k4n8-plugin/tests/dffs/dffs.v
+++ b/ql-qlf-k4n8-plugin/tests/dffs/dffs.v
@@ -3,7 +3,6 @@ module my_dff (
     clk,
     output reg q
 );
-  initial q <= 1'b0;
   always @(posedge clk) q <= d;
 endmodule
 
@@ -13,7 +12,6 @@ module my_dffr_p (
     clr,
     output reg q
 );
-  initial q <= 1'b0;
   always @(posedge clk or posedge clr)
     if (clr) q <= 1'b0;
     else q <= d;
@@ -25,7 +23,6 @@ module my_dffr_n (
     clr,
     output reg q
 );
-  initial q <= 1'b0;
   always @(posedge clk or negedge clr)
     if (!clr) q <= 1'b0;
     else q <= d;
@@ -37,7 +34,6 @@ module my_dffs_p (
     pre,
     output reg q
 );
-  initial q <= 1'b0;
   always @(posedge clk or posedge pre)
     if (pre) q <= 1'b1;
     else q <= d;
@@ -49,7 +45,6 @@ module my_dffs_n (
     pre,
     output reg q
 );
-  initial q <= 1'b0;
   always @(posedge clk or negedge pre)
     if (!pre) q <= 1'b1;
     else q <= d;

--- a/ql-qlf-k4n8-plugin/tests/iob_no_flatten/iob_no_flatten.v
+++ b/ql-qlf-k4n8-plugin/tests/iob_no_flatten/iob_no_flatten.v
@@ -3,7 +3,6 @@ module my_dff (
     clk,
     output reg q
 );
-  initial q <= 1'b0;
   always @(posedge clk) q <= d;
 endmodule
 


### PR DESCRIPTION
This PR fixes the order in which the two mentioned passes are invoked. It also fixes a bug in the shift register techmap.