### PR TITLE
XDC: Support loading properties from dictionaries

### DIFF
--- a/xdc-plugin/tests/Makefile
+++ b/xdc-plugin/tests/Makefile
@@ -1,9 +1,11 @@
 # counter - basic test for IOSTANDARD, SLEW, DRIVE, IN_TERM properties
+# counter-dict - basic test using XDC -dict for IOSTANDARD, SLEW, DRIVE, IN_TERM properties
 # port_indexes - like counter but bus port indices are passes without curly braces
 # io_loc_pairs - test for LOC property being set on IOBUFs as the IO_LOC_PAIRS parameter
 # minilitex_ddr_arty - litex design with more types of IOBUFS including differential
 # package_pins - test for PACKAGE_PIN property being set on IOBUFs as the IO_LOC_PAIRS parameter
 TESTS = counter \
+	counter-dict \
 	port_indexes \
 	io_loc_pairs \
 	minilitex_ddr_arty \
@@ -19,6 +21,7 @@ $(1)_update_json:
 endef
 
 counter_verify = $(call json_test,counter)
+counter-dict_verify = $(call json_test,counter-dict)
 port_indexes_verify = $(call json_test,port_indexes) && test $$(grep "'unknown' proc command handler" port_indexes/port_indexes.txt | wc -l) -eq 2
 io_loc_pairs_verify = $(call json_test,io_loc_pairs)
 minilitex_ddr_arty_verify = $(call json_test,minilitex_ddr_arty)

--- a/xdc-plugin/tests/counter-dict/counter-dict.golden.json
+++ b/xdc-plugin/tests/counter-dict/counter-dict.golden.json
@@ -1,0 +1,35 @@
+{
+  "OBUF_6": {
+    "DRIVE": "12",
+    "IOSTANDARD": "LVCMOS33",
+    "SLEW": "SLOW"
+  },
+  "OBUF_7": {
+    "IN_TERM": "UNTUNED_SPLIT_40",
+    "IOSTANDARD": "SSTL135",
+    "SLEW": "FAST"
+  },
+  "OBUF_OUT": {
+    "IN_TERM": "UNTUNED_SPLIT_50",
+    "IOSTANDARD": "LVCMOS33",
+    "SLEW": "FAST"
+  },
+  "bottom_inst.OBUF_10": {
+    "IOSTANDARD": "LVCMOS18",
+    "SLEW": "SLOW"
+  },
+  "bottom_inst.OBUF_11": {
+    "DRIVE": "4",
+    "IOSTANDARD": "LVCMOS25",
+    "SLEW": "FAST"
+  },
+  "bottom_inst.OBUF_9": {
+    "IOSTANDARD": "DIFF_SSTL135",
+    "SLEW": "FAST"
+  },
+  "bottom_intermediate_inst.OBUF_8": {
+    "DRIVE": "16",
+    "IOSTANDARD": "SSTL135",
+    "SLEW": "SLOW"
+  }
+}

--- a/xdc-plugin/tests/counter-dict/counter-dict.tcl
+++ b/xdc-plugin/tests/counter-dict/counter-dict.tcl
@@ -1,0 +1,16 @@
+yosys -import
+if { [info procs get_ports] == {} } { plugin -i design_introspection }
+if { [info procs read_xdc] == {} } { plugin -i xdc }
+yosys -import  ;# ingest plugin commands
+
+read_verilog $::env(DESIGN_TOP).v
+
+# -flatten is used to ensure that the output eblif has only one module.
+# Some of symbiflow expects eblifs with only one module.
+synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp
+
+#Read the design constraints
+read_xdc -part_json [file dirname $::env(DESIGN_TOP)]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
+
+# Write the design in JSON format.
+write_json [test_output_path "counter-dict.json"]

--- a/xdc-plugin/tests/counter-dict/counter-dict.v
+++ b/xdc-plugin/tests/counter-dict/counter-dict.v
@@ -1,0 +1,95 @@
+module top (
+    input clk,
+    output [3:0] led,
+    inout out_a,
+    output [1:0] out_b
+);
+
+  wire LD6, LD7, LD8, LD9;
+  wire inter_wire, inter_wire_2;
+  localparam BITS = 1;
+  localparam LOG2DELAY = 25;
+
+  reg [BITS+LOG2DELAY-1:0] counter = 0;
+
+  always @(posedge clk) begin
+    counter <= counter + 1;
+  end
+  assign led[1] = inter_wire;
+  assign inter_wire = inter_wire_2;
+  assign {LD9, LD8, LD7, LD6} = counter >> LOG2DELAY;
+  OBUF #(
+      .IOSTANDARD("LVCMOS33"),
+      .SLEW("SLOW")
+  ) OBUF_6 (
+      .I(LD6),
+      .O(led[0])
+  );
+  OBUF #(
+      .IOSTANDARD("LVCMOS33"),
+      .SLEW("SLOW")
+  ) OBUF_7 (
+      .I(LD7),
+      .O(inter_wire_2)
+  );
+  OBUF #(
+      .IOSTANDARD("LVCMOS33"),
+      .SLEW("SLOW")
+  ) OBUF_OUT (
+      .I(LD7),
+      .O(out_a)
+  );
+  bottom bottom_inst (
+      .I (LD8),
+      .O (led[2]),
+      .OB(out_b)
+  );
+  bottom_intermediate bottom_intermediate_inst (
+      .I(LD9),
+      .O(led[3])
+  );
+endmodule
+
+module bottom_intermediate (
+    input  I,
+    output O
+);
+  wire bottom_intermediate_wire;
+  assign O = bottom_intermediate_wire;
+  OBUF #(
+      .IOSTANDARD("LVCMOS33"),
+      .SLEW("SLOW")
+  ) OBUF_8 (
+      .I(I),
+      .O(bottom_intermediate_wire)
+  );
+endmodule
+
+module bottom (
+    input I,
+    output [1:0] OB,
+    output O
+);
+  OBUF #(
+      .IOSTANDARD("LVCMOS33"),
+      .SLEW("SLOW")
+  ) OBUF_9 (
+      .I(I),
+      .O(O)
+  );
+  OBUF #(
+      .IOSTANDARD("LVCMOS33"),
+      .SLEW("SLOW")
+  ) OBUF_10 (
+      .I(I),
+      .O(OB[0])
+  );
+  OBUF #(
+      .IOSTANDARD("LVCMOS33"),
+      .SLEW("SLOW")
+  ) OBUF_11 (
+      .I(I),
+      .O(OB[1])
+  );
+endmodule
+

--- a/xdc-plugin/tests/counter-dict/counter-dict.xdc
+++ b/xdc-plugin/tests/counter-dict/counter-dict.xdc
@@ -1,0 +1,20 @@
+#set_property LOC R2 [get_ports led]
+#OBUF_6
+set_property DRIVE 12 [get_ports {led[0]}]
+#OBUF_7
+set_property -dict { IN_TERM UNTUNED_SPLIT_40 SLEW FAST IOSTANDARD SSTL135 } [get_ports {led[1]}]
+#OBUF_OUT
+set_property -dict {IN_TERM UNTUNED_SPLIT_50 SLEW FAST IOSTANDARD LVCMOS33} [get_ports {out_a}]
+#bottom_inst.OBUF_10
+set_property -dict { SLEW SLOW IOSTANDARD LVCMOS18 } [get_ports {out_b[0]}]
+#bottom_inst.OBUF_11
+set_property -dict { DRIVE 4 SLEW FAST IOSTANDARD LVCMOS25 } [get_ports {out_b[1]}]
+#bottom_inst.OBUF_9
+set_property -dict { SLEW FAST IOSTANDARD DIFF_SSTL135 } [get_ports {led[2]}]
+#bottom_intermediate_inst.OBUF_8
+set_property -dict { DRIVE 16 IOSTANDARD SSTL135 } [get_ports {led[3]}]
+#set_property INTERNAL_VREF 0.600 [get_iobanks 14]
+#set_property INTERNAL_VREF 0.675 [get_iobanks 15]
+#set_property INTERNAL_VREF 0.750 [get_iobanks 16]
+#set_property INTERNAL_VREF 0.900 [get_iobanks 34]
+#set_property INTERNAL_VREF 0.900 [get_iobanks 35]


### PR DESCRIPTION
This change adds support to load pin properties from single-line
dictionaries.

Implementation and test-case were added. Test case mirrors `counter` case but with `-dict` properties (mixed usage in same file).

Fixes #32

Signed-off-by: Carlos de Paula <me@carlosedp.com>