### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -41,6 +41,7 @@ start_section Install-Yosys
         cd ~/.local-src
         git clone https://github.com/SymbiFlow/yosys.git -b master+wip
         cd yosys
+        make config-gcc # Build Yosys using GCC
         PREFIX=$HOME/.local-bin make -j$(nproc)
         PREFIX=$HOME/.local-bin make install
         echo $(which yosys)


### PR DESCRIPTION
As of version `20210510.0` of GH actions Ubuntu 20.04 image GCC 11 was added. Parts of the GCC 11 library used by clang (not sure how) make Yosys build fail. ~This PR solves that by uninstalling GCC 11 prior to Yosys compilation.~

This PR makes Yosys being built by GCC (version 9 in this case) instead of clang.