### PR TITLE
Fix adder mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The plugin adds the following command:
 
 The plugin adds the following command:
 * synth_quicklogic
+* ql_dsp
 
 Detailed help on the supported command(s) can be obtained by running `help <command_name>` in Yosys.
 

--- a/ql-qlf-plugin/qlf_k6n10/arith_map.v
+++ b/ql-qlf-plugin/qlf_k6n10/arith_map.v
@@ -38,10 +38,30 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 	endgenerate
 
 	wire [Y_WIDTH: 0 ] CARRY;
-	assign CARRY[0] = CI;
+
+	// Due to VPR limitations regarding IO connexion to carry chain,
+	// we generate the carry chain input signal using an intermediate adder
+	// since we can connect a & b from io pads, but not cin & cout
+	generate
+	     adder intermediate_adder (
+	       .cin     ( ),
+	       .cout    (CARRY[0]),
+	       .a       (CI     ),
+	       .b       (CI     ),
+	       .sumout  (      )
+	     );
+
+	     adder first_adder (
+	       .cin     (CARRY[0]),
+	       .cout    (CARRY[1]),
+	       .a       (AA[0]  ),
+	       .b       (BB[0]  ),
+	       .sumout  (Y[0]   )
+	     );
+	endgenerate
 
 	genvar i;
-	generate for (i = 0; i < Y_WIDTH - 1; i = i+1) begin:gen3
+	generate for (i = 1; i < Y_WIDTH - 1; i = i+1) begin:gen3
 	     adder my_adder (
 	       .cin     (CARRY[i]  ),
 	       .cout    (CARRY[i+1]),
@@ -50,19 +70,6 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 	       .sumout  (Y[i]      )
 	     );
 	end endgenerate
-
-	generate if ((Y_WIDTH -1) % 20 == 0) begin:gen4
-	     assign Y[Y_WIDTH-1] = CARRY[Y_WIDTH-1];
-	end else begin:gen5
-	     adder my_adder (
-	       .cin     (CARRY[Y_WIDTH - 1]),
-	       .cout    (CARRY[Y_WIDTH]    ),
-	       .a       (1'b0              ),
-	       .b       (1'b0              ),
-	       .sumout  (Y[Y_WIDTH -1]     )
-	     );
-	end
-	endgenerate
 	assign X = AA ^ BB;
 endmodule
 

--- a/ql-qlf-plugin/qlf_k6n10/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10/cells_sim.v
@@ -63,7 +63,7 @@ module frac_lut6(
     assign lut4_out[2] = s4[2];
     assign lut4_out[3] = s4[3];
 
-    assign lut5_out[0] = s0[0];
+    assign lut5_out[0] = s5[0];
     assign lut5_out[1] = s5[1];
 
     assign lut6_out = li[5] ? s5[0] : s5[1];
@@ -182,7 +182,7 @@ module dffse(
     (* invertible_pin = "IS_C_INVERTED" *)
     input C,
     input S,
-    input E,
+    input E
 );
     parameter [0:0] INIT = 1'b0;
     parameter [0:0] IS_C_INVERTED = 1'b0;

--- a/ql-qlf-plugin/tests/full_adder/full_adder.tcl
+++ b/ql-qlf-plugin/tests/full_adder/full_adder.tcl
@@ -17,21 +17,26 @@ yosys proc
 equiv_opt -assert  -map +/quicklogic/qlf_k4n8/cells_sim.v synth_quicklogic -family qlf_k4n8
 
 design -reset
+
 # Equivalence check for adder synthesis for qlf-k6n10
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top full_adder
 yosys proc
-equiv_opt -assert -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10
+synth_quicklogic -family qlf_k6n10
+yosys cd full_adder
+stat
+select -assert-count 5 t:adder
 
 design -reset
 
-#TODO: Fix equivalence check for substractor design with qlf_k6n10 device
-
-## Equivalence check for subtractor synthesis
-#read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
-#hierarchy -check -top subtractor
-#yosys proc
-#equiv_opt -assert  -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10
+# Equivalence check for subtractor synthesis for qlf-k6n10
+read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
+hierarchy -check -top subtractor
+yosys proc
+synth_quicklogic -family qlf_k6n10
+yosys cd subtractor
+stat
+select -assert-count 5 t:adder
 
 design -reset
 


### PR DESCRIPTION
This PR modifies adders mapping for the qlf_k6n10 device.
The carry chain input is now longer directly connected to the first adder in chain CIN, but is generated using an intermediate adder.

This PR also reference ql_dsp function as part of the ql-qlf plugin in the main readme, and fix a typo qlf_k6n10 cells sim file.