### PR TITLE
Rectifying the port name as 'a' instead of 'A' for logic_0 and logic_…

### DIFF
--- a/ql-qlf-plugin/pp3/pp3_cells_sim.v
+++ b/ql-qlf-plugin/pp3/pp3_cells_sim.v
@@ -21,15 +21,15 @@ module buff (
 endmodule
 
 module logic_0 (
-    output A
+    output a
 );
-  assign A = 0;
+  assign a = 0;
 endmodule
 
 module logic_1 (
-    output A
+    output a
 );
-  assign A = 1;
+  assign a = 1;
 endmodule
 
 module gclkbuff (

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -358,7 +358,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                 run("setundef -zero -params -undriven");
             }
             if (family == "pp3" || (check_label("edif") && (!edif_file.empty()))) {
-                run("hilomap -hicell logic_1 A -locell logic_0 A -singleton A:top");
+                run("hilomap -hicell logic_1 a -locell logic_0 a -singleton A:top");
             }
             run("opt_clean -purge");
             run("check");


### PR DESCRIPTION
…1 for pp3 device family