### PR TITLE
Add YOSYS_PATH to the makefile

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -32,7 +32,7 @@ end_section
 ##########################################################################
 
 start_section Cleanup
-make clean -j`nproc`
+make plugins_clean -j`nproc`
 end_section
 
 ##########################################################################

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ install: $(PLUGINS_INSTALL)
 
 test: $(PLUGINS_TEST)
 
-clean:: $(PLUGINS_CLEAN)
+plugins_clean: $(PLUGINS_CLEAN)
+
+clean:: plugins_clean
 
 CLANG_FORMAT ?= clang-format-8
 format:

--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -37,12 +37,22 @@
 # |       |   |-- ...
 # |-- example2-plugin
 # |-- ...
-CXX ?= $(shell yosys-config --cxx)
-CXXFLAGS ?= $(shell yosys-config --cxxflags) #-DSDC_DEBUG
-LDFLAGS ?= $(shell yosys-config --ldflags)
-LDLIBS ?= $(shell yosys-config --ldlibs)
-PLUGINS_DIR ?= $(shell yosys-config --datdir)/plugins
-DATA_DIR ?= $(shell yosys-config --datdir)
+
+# Either find yosys in system and use its path or use the given path
+YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
+
+# Find yosys-config, throw an error if not found
+YOSYS_CONFIG = $(YOSYS_PATH)/bin/yosys-config
+ifeq (,$(wildcard $(YOSYS_CONFIG)))
+$(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
+endif
+
+CXX ?= $(shell $(YOSYS_CONFIG) --cxx)
+CXXFLAGS ?= $(shell $(YOSYS_CONFIG) --cxxflags) #-DSDC_DEBUG
+LDFLAGS ?= $(shell $(YOSYS_CONFIG) --ldflags)
+LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs)
+PLUGINS_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)/plugins
+DATA_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)
 
 OBJS := $(SOURCES:cc=o)
 

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -13,11 +13,21 @@
 # test1_verify = $(call diff_test,test1,ext) && test $$(grep "PASS" test1/test1.txt | wc -l) -eq 2
 # test2_verify = $(call diff_test,test2,ext)
 #
+
+# Either find yosys in system and use its path or use the given path
+YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
+
+# Find yosys-config, throw an error if not found
+YOSYS_CONFIG = $(YOSYS_PATH)/bin/yosys-config
+ifeq (,$(wildcard $(YOSYS_CONFIG)))
+$(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
+endif
+
 GTEST_DIR ?= ../../third_party/googletest/googletest
-CXX ?= $(shell yosys-config --cxx)
-CXXFLAGS ?= $(shell yosys-config --cxxflags) -I.. -I$(GTEST_DIR)/include
-LDLIBS ?= $(shell yosys-config --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
-LDFLAGS ?= $(shell yosys-config --ldflags)
+CXX ?= $(shell $(YOSYS_CONFIG) --cxx)
+CXXFLAGS ?= $(shell $(YOSYS_CONFIG) --cxxflags) -I.. -I$(GTEST_DIR)/include
+LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
+LDFLAGS ?= $(shell $(YOSYS_CONFIG) --ldflags)
 TEST_UTILS ?= ../../../test-utils/test-utils.tcl
 
 define test_tpl =


### PR DESCRIPTION
This PR adds the way to manually specify path to Yosys installation via the `YOSYS_PATH` make variable. To do that one would simple run for example:
```
make plugins YOSYS_PATH=/opt/yosys
```