### PR TITLE
Optional Conda make-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,7 @@ TOP_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 REQUIREMENTS_FILE ?= requirements.txt
 ENVIRONMENT_FILE ?= environment.yml
 
-include third_party/make-env/conda.mk
-
-env:: | $(CONDA_ENV_PYTHON)
+-include third_party/make-env/conda.mk
 
 define install_plugin =
 $(1).so:


### PR DESCRIPTION
This PR adds optional inclusion of the makefile from Conda env so that the plugins can be built and installed outside of it.