### PR TITLE
ql-qlf: add possibility to override synth pass name through define

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
 
     - name: Build and test plugins
       run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         if [ "$BUILD_UPSTREAM" = "1" ]; then source env/conda/bin/activate yosys-plugins; fi
         source .github/workflows/build-and-test.sh
       env:

--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -53,8 +53,14 @@ LDFLAGS ?= $(shell $(YOSYS_CONFIG) --ldflags)
 LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs)
 PLUGINS_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)/plugins
 DATA_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)
+EXTRA_FLAGS ?=
 
 OBJS := $(SOURCES:cc=o)
+
+all: $(NAME).so
+
+$(OBJS): %.o: %.cc
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_FLAGS) $(EXTRA_FLAGS) -c -o $@ $^
 
 $(NAME).so: $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)

--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -60,7 +60,7 @@ OBJS := $(SOURCES:cc=o)
 all: $(NAME).so
 
 $(OBJS): %.o: %.cc
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_FLAGS) $(EXTRA_FLAGS) -c -o $@ $^
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_FLAGS) -c -o $@ $^
 
 $(NAME).so: $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -24,14 +24,21 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
+#define XSTR(val) #val
+#define STR(val) XSTR(val)
+
+#ifndef PASS_NAME
+#define PASS_NAME synth_quicklogic
+#endif
+
 struct SynthQuickLogicPass : public ScriptPass {
 
-    SynthQuickLogicPass() : ScriptPass("synth_quicklogic", "Synthesis for QuickLogic FPGAs") {}
+    SynthQuickLogicPass() : ScriptPass(STR(PASS_NAME), "Synthesis for QuickLogic FPGAs") {}
 
     void help() override
     {
         log("\n");
-        log("   synth_quicklogic [options]\n");
+        log("   %s [options]\n", STR(PASS_NAME));
         log("This command runs synthesis for QuickLogic FPGAs\n");
         log("\n");
         log("    -top <module>\n");


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds the possibility to override the `synth_quicklogic` pass name when building the plugin.

The pass name can be overriden by setting an extra flag as follows:
```
make EXTRA_FLAGS="-DPASS_NAME=new_name"
```