### PR TITLE
uhdm-plugin: look also at lib64 folder for libraries

### DIFF
--- a/uhdm-plugin/Makefile
+++ b/uhdm-plugin/Makefile
@@ -22,5 +22,5 @@ CXXFLAGS += -DBUILD_UPSTREAM=1
 endif
 
 CXXFLAGS += -Wno-unused-parameter
-LDFLAGS += -L${UHDM_INSTALL_DIR}/lib/uhdm -L${UHDM_INSTALL_DIR}/lib/surelog -L${UHDM_INSTALL_DIR}/lib
+LDFLAGS += -L${UHDM_INSTALL_DIR}/lib/uhdm -L${UHDM_INSTALL_DIR}/lib/surelog -L${UHDM_INSTALL_DIR}/lib -L${UHDM_INSTALL_DIR}/lib64/uhdm -L${UHDM_INSTALL_DIR}/lib64/surelog -L${UHDM_INSTALL_DIR}/lib64
 LDLIBS += -Wl,--whole-archive -luhdm -Wl,--no-whole-archive -lsurelog -lantlr4-runtime -lflatbuffers -lcapnp -lkj -ldl -lutil -lm -lrt -lpthread


### PR DESCRIPTION
On some system, Surelog libraries are installed in ``lib64`` folder.

This PR adds this path to ``LDFLAGS``.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>