### PR TITLE
xdc: fix port numbering

### DIFF
--- a/xdc-plugin/tests/Makefile
+++ b/xdc-plugin/tests/Makefile
@@ -13,13 +13,15 @@
 # io_loc_pairs - test for LOC property being set on IOBUFs as the IO_LOC_PAIRS parameter
 # minilitex_ddr_arty - litex design with more types of IOBUFS including differential
 # package_pins - test for PACKAGE_PIN property being set on IOBUFs as the IO_LOC_PAIRS parameter
+# non_zero_port_indexes - testing IO_LOC_PAIRS for design with non-zero indexed ports
 TESTS = counter \
 	counter-dict \
 	package_pins-dict-space \
 	port_indexes \
 	io_loc_pairs \
 	minilitex_ddr_arty \
-	package_pins
+	package_pins \
+	non_zero_port_indexes
 
 include $(shell pwd)/../../Makefile_test.common
 
@@ -37,3 +39,4 @@ io_loc_pairs_verify = $(call json_test,io_loc_pairs)
 minilitex_ddr_arty_verify = $(call json_test,minilitex_ddr_arty)
 package_pins_verify = $(call json_test,package_pins)
 package_pins-dict-space_verify = $(call json_test,package_pins-dict-space)
+non_zero_port_indexes_verify = $(call json_test,non_zero_port_indexes)

--- a/xdc-plugin/tests/non_zero_port_indexes/non_zero_port_indexes.golden.json
+++ b/xdc-plugin/tests/non_zero_port_indexes/non_zero_port_indexes.golden.json
@@ -1,0 +1,18 @@
+{
+	"$iopadmap$top.LED": {
+		"IOSTANDARD": "LVCMOS33",
+		"IO_LOC_PAIRS": "LED[2]:H5"
+	},
+	"$iopadmap$top.LED_1": {
+		"IOSTANDARD": "LVCMOS33",
+		"IO_LOC_PAIRS": "LED[3]:J5"
+	},
+	"$iopadmap$top.LED_2": {
+		"IOSTANDARD": "LVCMOS33",
+		"IO_LOC_PAIRS": "LED[4]:T9"
+	},
+	"$iopadmap$top.LED_3": {
+		"IOSTANDARD": "LVCMOS33",
+		"IO_LOC_PAIRS": "LED[5]:T10"
+	}
+}

--- a/xdc-plugin/tests/non_zero_port_indexes/non_zero_port_indexes.tcl
+++ b/xdc-plugin/tests/non_zero_port_indexes/non_zero_port_indexes.tcl
@@ -1,0 +1,25 @@
+yosys -import
+if { [info procs get_ports] == {} } { plugin -i design_introspection }
+if { [info procs read_xdc] == {} } { plugin -i xdc }
+yosys -import  ;# ingest plugin commands
+
+read_verilog $::env(DESIGN_TOP).v
+
+read_verilog -lib -specify +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+
+hierarchy -check -top top
+
+# -flatten is used to ensure that the output eblif has only one module.
+# Some of symbiflow expects eblifs with only one module.
+synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp -run prepare:check
+
+#Read the design constraints
+read_xdc -part_json [file dirname $::env(DESIGN_TOP)]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
+
+# Clean processes before writing JSON.
+yosys proc
+
+# Write the design in JSON format.
+write_json [test_output_path "non_zero_port_indexes.json"]
+write_blif -param [test_output_path "non_zero_port_indexes.eblif"]

--- a/xdc-plugin/tests/non_zero_port_indexes/non_zero_port_indexes.v
+++ b/xdc-plugin/tests/non_zero_port_indexes/non_zero_port_indexes.v
@@ -1,0 +1,15 @@
+// Copyright (C) 2020-2021  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
+module top(
+           output [5:2] LED
+           );
+
+   assign LED[5:2] = 4'b1010;
+
+endmodule

--- a/xdc-plugin/tests/non_zero_port_indexes/non_zero_port_indexes.xdc
+++ b/xdc-plugin/tests/non_zero_port_indexes/non_zero_port_indexes.xdc
@@ -1,0 +1,4 @@
+set_property -dict { PACKAGE_PIN H5   IOSTANDARD LVCMOS33 } [get_ports { LED[2] }];
+set_property -dict { PACKAGE_PIN J5   IOSTANDARD LVCMOS33 } [get_ports { LED[3] }];
+set_property -dict { PACKAGE_PIN T9   IOSTANDARD LVCMOS33 } [get_ports { LED[4] }];
+set_property -dict { PACKAGE_PIN T10   IOSTANDARD LVCMOS33 } [get_ports { LED[5] }];

--- a/xdc-plugin/xdc.cc
+++ b/xdc-plugin/xdc.cc
@@ -342,7 +342,11 @@ struct SetProperty : public Pass {
         if (signal.is_chunk()) {
             auto chunk = signal.as_chunk();
             if (chunk.wire) {
-                return (chunk.wire->name == RTLIL::IdString(RTLIL::escape_id(port))) && (port_bit == chunk.offset);
+                // chunk.offset is always indexed from 0. Because of that port_bit must be
+                // corrected with the chunk.wire->start_offset of the port wire in case it is not 0-indexed.
+                // Not doing this would cause lack of some properties (e.g. IO_LOC_PAIRS) for
+                // non-0-indexed ports in final eblif file
+                return (chunk.wire->name == RTLIL::IdString(RTLIL::escape_id(port))) && ((port_bit - chunk.wire->start_offset) == chunk.offset);
             }
         }
         return false;


### PR DESCRIPTION
This PR fixes a bug in XDC plugin that was described in https://github.com/SymbiFlow/yosys-symbiflow-plugins/issues/144
`port_bit` returned by `extract_signal()` is the same as index of given port wire, while `chunk.offset`s are always indexed starting from 0. That causes inconsistency when ports of the module are not 0-indexed as in example:
```
module Top(
           output [5:2] LED
           );
```
This required correcting `port_bit` with `start_offset` of the whole port.

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>