### PR TITLE
Fail when event_control is not inside always

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -2012,12 +2012,15 @@ void UhdmAst::process_always()
     }
 }
 
-void UhdmAst::process_event_control()
+void UhdmAst::process_event_control(const UHDM::BaseClass *object)
 {
     current_node = make_ast_node(AST::AST_BLOCK);
     visit_one_to_one({vpiCondition}, obj_h, [&](AST::AstNode *node) {
         if (node) {
             auto process_node = find_ancestor({AST::AST_ALWAYS});
+            if (!process_node) {
+                log_error("%s:%d: Currently supports only event control stmts inside 'always'\n", object->VpiFile().c_str(), object->VpiLineNo());
+            }
             process_node->children.push_back(node);
         }
         // is added inside vpiOperation
@@ -3499,7 +3502,7 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
         process_always();
         break;
     case vpiEventControl:
-        process_event_control();
+        process_event_control(object);
         break;
     case vpiInitial:
         process_initial();

--- a/uhdm-plugin/UhdmAst.h
+++ b/uhdm-plugin/UhdmAst.h
@@ -94,7 +94,7 @@ class UhdmAst
     void process_modport();
     void process_io_decl();
     void process_always();
-    void process_event_control();
+    void process_event_control(const UHDM::BaseClass *object);
     void process_initial();
     void process_begin();
     void process_operation();


### PR DESCRIPTION
Fixes: https://github.com/antmicro/yosys-uhdm-plugin-integration/issues/258
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>