### PR TITLE
Remove BUILD_UPSTREAM variable

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -15,12 +15,7 @@ source .github/workflows/common.sh
 
 start_section Building
 
-if [ "$BUILD_UPSTREAM" = "0" ]
-then
-	make UHDM_INSTALL_DIR=$HOME/.local-bin plugins -j`nproc`
-else
-	make UHDM_INSTALL_DIR=`pwd`/env/conda/envs/yosys-plugins/ plugins -j`nproc`
-fi
+make UHDM_INSTALL_DIR=`pwd`/env/conda/envs/yosys-plugins/ plugins -j`nproc`
 end_section
 
 ##########################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,6 @@ jobs:
 
   Run-tests:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - {BUILD_UPSTREAM: "0"}
-          - {BUILD_UPSTREAM: "1"}
-
-    name: "UHDM_BUILD_UPSTREAM_YOSYS=${{matrix.BUILD_UPSTREAM}}"
 
     steps:
 
@@ -46,8 +38,6 @@ jobs:
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: ${{ matrix.BUILD_UPSTREAM }}
 
     - name: Install Yosys
       run: |
@@ -55,13 +45,11 @@ jobs:
         source .github/workflows/setup.sh
       env:
         OS: ${{ runner.os }}
-        BUILD_UPSTREAM: ${{ matrix.BUILD_UPSTREAM }}
 
     - name: Build and test plugins
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ "$BUILD_UPSTREAM" = "1" ]; then source env/conda/bin/activate yosys-plugins; fi
+        source env/conda/bin/activate yosys-plugins
         source .github/workflows/build-and-test.sh
       env:
         OS: ${{ runner.os }}
-        BUILD_UPSTREAM: ${{ matrix.BUILD_UPSTREAM }}

--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -42,27 +42,8 @@ start_section Install-Yosys
     echo '=========================='
     echo 'Making env with yosys and Surelog'
     echo '=========================='
-    if [ "$BUILD_UPSTREAM" = "0" ]
-    then
-	mkdir -p ~/.local-src
-	mkdir -p ~/.local-bin
-	cd ~/.local-src
-	git clone https://github.com/antmicro/yosys.git -b uhdm-plugin
-	cd yosys
-	PREFIX=$HOME/.local-bin make CONFIG=gcc ENABLE_NDEBUG=1 -j$(nproc)
-	PREFIX=$HOME/.local-bin make install
-	cd ..
-	git clone --recursive https://github.com/chipsalliance/Surelog.git -b master
-	cd Surelog
-	pip install orderedmultidict
-	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/.local-bin -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S . -B build
-	cmake --build build -j $(nproc)
-	cmake --install build
-	cd ../..
-    else
-	make env
-	make enter
-    fi
+    make env
+    make enter
     echo $(which yosys)
     echo $(which yosys-config)
     echo $(yosys-config --datdir)

--- a/uhdm-plugin/Makefile
+++ b/uhdm-plugin/Makefile
@@ -18,10 +18,6 @@ CPPFLAGS += -std=c++17 -Wall -W -Wextra -Werror \
               -I${UHDM_INSTALL_DIR}/include \
 	      -I${UHDM_INSTALL_DIR}/include/surelog
 
-ifeq ($(BUILD_UPSTREAM), 1)
-CXXFLAGS += -DBUILD_UPSTREAM=1
-endif
-
 CXXFLAGS += -Wno-unused-parameter
 LDFLAGS += -L${UHDM_INSTALL_DIR}/lib/uhdm -L${UHDM_INSTALL_DIR}/lib/surelog -L${UHDM_INSTALL_DIR}/lib -L${UHDM_INSTALL_DIR}/lib64/uhdm -L${UHDM_INSTALL_DIR}/lib64/surelog -L${UHDM_INSTALL_DIR}/lib64
 LDLIBS += -Wl,--whole-archive -luhdm -Wl,--no-whole-archive -lsurelog -lantlr4-runtime -lflatbuffers -lcapnp -lkj -ldl -lutil -lm -lrt -lpthread

--- a/uhdm-plugin/UhdmAst.h
+++ b/uhdm-plugin/UhdmAst.h
@@ -136,7 +136,6 @@ class UhdmAst
     void simplify_parameter(AST::AstNode *parameter, AST::AstNode *module_node = nullptr);
     void process_nonsynthesizable(const UHDM::BaseClass *object);
     void process_unsupported_stmt(const UHDM::BaseClass *object);
-    void visitEachDescendant(AST::AstNode *node, const std::function<void(AST::AstNode *)> &f);
 
     UhdmAst(UhdmAst *p, UhdmAstShared &s, const std::string &i) : parent(p), shared(s), indent(i)
     {

--- a/uhdm-plugin/UhdmAstAntmicro.cc
+++ b/uhdm-plugin/UhdmAstAntmicro.cc
@@ -1,9 +1,0 @@
-namespace RTLIL
-{
-namespace ID
-{
-IdString packed_ranges{"\\packed_ranges"};
-IdString unpacked_ranges{"\\unpacked_ranges"};
-} // namespace ID
-} // namespace RTLIL
-#define mkconst_real(x) AST::AstNode::mkconst_real(x)

--- a/uhdm-plugin/uhdmastshared.h
+++ b/uhdm-plugin/uhdmastshared.h
@@ -46,11 +46,8 @@ class UhdmAstShared
 
     // Map from AST param nodes to their types (used for params with struct types)
     std::unordered_map<std::string, AST::AstNode *> param_types;
-#ifdef BUILD_UPSTREAM
-    std::vector<std::string> multirange_scope;
 
     AST::AstNode *current_top_node = nullptr;
-#endif
 };
 
 YOSYS_NAMESPACE_END


### PR DESCRIPTION
Now we should always targeting upstream yosys and this variable is no longer needed.
Some features that are still opened as PR to mainline yosys, requires patched yosys.

After merging this PR we need to make sure all repositories using uhdm-plugin reflects this change:
- [ ] yosys-uhdm-plugin-integration - https://github.com/antmicro/yosys-uhdm-plugin-integration/pull/307
- [ ] sv-tests - https://github.com/chipsalliance/sv-tests/pull/2030
- [ ] conda-eda - https://github.com/hdl/conda-eda/pull/155
- [x] ~~fpga-tool-perf~~ - changes in ``conda-eda`` should be sufficient, as this repository is only using package

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>