### PR TITLE
Don't reverse only flattened nodes

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -2479,6 +2479,10 @@ void UhdmAst::process_assignment_pattern_op()
         for (auto p : ordered_children) {
             current_node->children.push_back(p.second);
         }
+        // flattened nodes have correct order, but unflattened ones still needs to be reversed
+        if (!(vpi_get(vpiFlattened, obj_h) == 1)) {
+            std::reverse(current_node->children.begin(), current_node->children.end());
+        }
         return;
     }
     auto assign_node = find_ancestor({AST::AST_ASSIGN, AST::AST_ASSIGN_EQ, AST::AST_ASSIGN_LE});


### PR DESCRIPTION
Not flattened nodes still needs to be reversed to get correct order.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>