### PR TITLE
Update googletest

### DIFF
--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -23,9 +23,9 @@ ifeq (,$(wildcard $(YOSYS_CONFIG)))
 $(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
 endif
 
-GTEST_DIR ?= ../../third_party/googletest/googletest
+GTEST_DIR ?= ../../third_party/googletest
 CXX ?= $(shell $(YOSYS_CONFIG) --cxx)
-CXXFLAGS ?= $(shell $(YOSYS_CONFIG) --cxxflags) -I.. -I$(GTEST_DIR)/include
+CXXFLAGS ?= $(shell $(YOSYS_CONFIG) --cxxflags) -I.. -I$(GTEST_DIR)/googletest/include
 LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
 LDFLAGS ?= $(shell $(YOSYS_CONFIG) --ldflags)
 TEST_UTILS ?= ../../../test-utils/test-utils.tcl


### PR DESCRIPTION
Update the googletest submodule to get rid of the [maybe-uninitialized](https://github.com/google/googletest/pull/3024) warning and have a newer googletest version.