### PR TITLE
Make const2ast() static, as there is already the same symbol in Yosys.

### DIFF
--- a/uhdm-plugin/UhdmAstUpstream.cc
+++ b/uhdm-plugin/UhdmAstUpstream.cc
@@ -131,7 +131,7 @@ static void my_strtobin(std::vector<RTLIL::State> &data, const char *str, int le
 }
 
 // convert the Verilog code for a constant to an AST node
-AST::AstNode *const2ast(std::string code, char case_type, bool warn_z)
+static AST::AstNode *const2ast(std::string code, char case_type, bool warn_z)
 {
     if (warn_z) {
         AST::AstNode *ret = const2ast(code, case_type, false);


### PR DESCRIPTION
This results in duplicate-symbol link errors when linking the uhdm module
statically to yosys.

Signed-off-by: Henner Zeller <hzeller@google.com>