### PR TITLE
Avoid problematic global initialization of IdStrings.

### DIFF
--- a/uhdm-plugin/UhdmAst.h
+++ b/uhdm-plugin/UhdmAst.h
@@ -152,6 +152,13 @@ class UhdmAst
 
     // Visits all VPI design objects and returns created ASTs
     AST::AstNode *visit_designs(const std::vector<vpiHandle> &designs);
+
+    static const IdString &partial();
+    static const IdString &packed_ranges();
+    static const IdString &unpacked_ranges();
+    // set this attribute to force conversion of multirange wire to single range. It is useful to force-convert some memories.
+    static const IdString &force_convert();
+    static const IdString &is_imported();
 };
 
 YOSYS_NAMESPACE_END

--- a/uhdm-plugin/UhdmAstUpstream.cc
+++ b/uhdm-plugin/UhdmAstUpstream.cc
@@ -1,16 +1,3 @@
-namespace RTLIL
-{
-namespace ID
-{
-IdString partial{"\\partial"};
-IdString packed_ranges{"\\packed_ranges"};
-IdString unpacked_ranges{"\\unpacked_ranges"};
-IdString force_convert{
-  "\\force_convert"}; // set this attribute to force conversion of multirange wire to single range. It is useful to force-convert some memories.
-IdString is_imported{"\\is_imported"};
-} // namespace ID
-} // namespace RTLIL
-
 namespace AST
 {
 enum AstNodeTypeExtended {


### PR DESCRIPTION
Global initialization in c++ results in undefined initialization
sequences. In particular when the uhdm-plugin is linked statically
to yosys, this results in a crash.

Fixed by creating the constants on first use.

Signed-off-by: Henner Zeller <hzeller@google.com>