### PR TITLE
Add several fixes for segmentation faults

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -2411,6 +2411,9 @@ void UhdmAst::process_assignment_pattern_op()
                 auto key = node->children[0]->str;
                 key = key.substr(key.find('.') + 1);
                 auto param_type = shared.param_types[param_node->str];
+                if (!param_type) {
+                    log_error("Couldn't find parameter type for node: %s\n", param_node->str.c_str());
+                }
                 size_t pos =
                   std::find_if(param_type->children.begin(), param_type->children.end(), [key](AST::AstNode *child) { return child->str == key; }) -
                   param_type->children.begin();

--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1043,12 +1043,13 @@ AST::AstNode *UhdmAst::find_ancestor(const std::unordered_set<AST::AstNodeType> 
 void UhdmAst::process_design()
 {
     current_node = make_ast_node(AST::AST_DESIGN);
-    visit_one_to_many({UHDM::uhdmallInterfaces, UHDM::uhdmallPackages, UHDM::uhdmallModules, UHDM::uhdmtopModules, vpiTypedef}, obj_h,
-                      [&](AST::AstNode *node) {
-                          if (node) {
-                              shared.top_nodes[node->str] = node;
-                          }
-                      });
+    visit_one_to_many(
+      {UHDM::uhdmallInterfaces, UHDM::uhdmallPackages, UHDM::uhdmallModules, UHDM::uhdmtopModules, vpiTypedef, vpiParameter, vpiParamAssign}, obj_h,
+      [&](AST::AstNode *node) {
+          if (node) {
+              shared.top_nodes[node->str] = node;
+          }
+      });
     for (auto pair : shared.top_nodes) {
         if (!pair.second)
             continue;
@@ -2968,7 +2969,11 @@ void UhdmAst::process_bit_typespec()
         }
     });
     if (!current_node->str.empty()) {
-        move_type_to_new_typedef(find_ancestor({AST::AST_MODULE, AST::AST_PACKAGE}), current_node);
+        auto top_module = find_ancestor({AST::AST_MODULE, AST::AST_PACKAGE, AST::AST_DESIGN});
+        if (!top_module) {
+            log_error("Couldn't find top module for typedef: %s\n", current_node->str.c_str());
+        }
+        move_type_to_new_typedef(top_module, current_node);
     }
 }
 

--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1818,7 +1818,7 @@ void UhdmAst::process_package()
         }
     });
     visit_one_to_many({vpiTypedef}, obj_h, [&](AST::AstNode *node) {
-        if (node) {
+        if (node && node->str != "") {
             move_type_to_new_typedef(current_node, node);
         }
     });
@@ -2898,7 +2898,11 @@ void UhdmAst::process_logic_typespec()
     visit_one_to_many({vpiRange}, obj_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
     add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
     if (!current_node->str.empty()) {
-        move_type_to_new_typedef(find_ancestor({AST::AST_MODULE, AST::AST_PACKAGE}), current_node->clone());
+        auto top_module = find_ancestor({AST::AST_MODULE, AST::AST_PACKAGE, AST::AST_DESIGN});
+        if (!top_module) {
+            log_error("Couldn't find top module for typedef: %s\n", current_node->str.c_str());
+        }
+        move_type_to_new_typedef(top_module, current_node->clone());
     }
 }
 
@@ -2914,7 +2918,11 @@ void UhdmAst::process_int_typespec()
     add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
     current_node->is_signed = true;
     if (!current_node->str.empty()) {
-        move_type_to_new_typedef(find_ancestor({AST::AST_MODULE, AST::AST_PACKAGE}), current_node);
+        auto top_module = find_ancestor({AST::AST_MODULE, AST::AST_PACKAGE, AST::AST_DESIGN});
+        if (!top_module) {
+            log_error("Couldn't find top module for typedef: %s\n", current_node->str.c_str());
+        }
+        move_type_to_new_typedef(top_module, current_node);
     }
 }
 

--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -2515,6 +2515,9 @@ void UhdmAst::process_if_else()
 {
     current_node = make_ast_node(AST::AST_CASE);
     visit_one_to_one({vpiCondition}, obj_h, [&](AST::AstNode *node) {
+        if (!node) {
+            log_error("Couldn't find node in if stmt. This can happend if unsupported '$value$plusargs' function is used inside if.\n");
+        }
         auto reduce_node = new AST::AstNode(AST::AST_REDUCE_BOOL, node);
         current_node->children.push_back(reduce_node);
     });


### PR DESCRIPTION
This PR fixes several cases when uhdm-plugin results in segmentation fault.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>