### PR TITLE
sdc: Allow -add option in the create_clock command

### DIFF
--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -131,6 +131,9 @@ struct CreateClockCmd : public Pass {
         }
         for (argidx = 1; argidx < args.size(); argidx++) {
             std::string arg = args[argidx];
+            if (arg == "-add" && argidx + 1 < args.size()) {
+                continue;
+            }
             if (arg == "-name" && argidx + 1 < args.size()) {
                 name = args[++argidx];
                 continue;

--- a/sdc-plugin/tests/Makefile
+++ b/sdc-plugin/tests/Makefile
@@ -32,7 +32,8 @@ TESTS = abc9 \
 	period_check \
 	waveform_check \
 	period_format_check \
-	get_clocks
+	get_clocks \
+	create_clock_add
 
 UNIT_TESTS = escaping
 
@@ -58,3 +59,4 @@ waveform_check_negative = 1
 period_format_check_verify = true
 period_format_check_negative = 1
 get_clocks_verify = $(call diff_test,get_clocks,txt)
+create_clock_add_verify = $(call diff_test,create_clock_add,sdc) && $(call diff_test,create_clock_add,txt)

--- a/sdc-plugin/tests/create_clock_add/create_clock_add.golden.sdc
+++ b/sdc-plugin/tests/create_clock_add/create_clock_add.golden.sdc
@@ -1,0 +1,1 @@
+create_clock -period 10 -waveform {0 5} clk_int_1

--- a/sdc-plugin/tests/create_clock_add/create_clock_add.golden.txt
+++ b/sdc-plugin/tests/create_clock_add/create_clock_add.golden.txt
@@ -1,0 +1,2 @@
+clk clk2 clk_int_1
+clk clk2 clk_int_1

--- a/sdc-plugin/tests/create_clock_add/create_clock_add.input.sdc
+++ b/sdc-plugin/tests/create_clock_add/create_clock_add.input.sdc
@@ -1,0 +1,2 @@
+create_clock -add -period 10.0 -waveform {0.000 5.000} clk_int_1
+create_clock -add -period 10.0 -name clk -waveform {0.000 5.000} clk clk2

--- a/sdc-plugin/tests/create_clock_add/create_clock_add.tcl
+++ b/sdc-plugin/tests/create_clock_add/create_clock_add.tcl
@@ -1,0 +1,29 @@
+yosys -import
+if { [info procs read_sdc] == {} } { plugin -i sdc }
+yosys -import  ;# ingest plugin commands
+
+read_verilog $::env(DESIGN_TOP).v
+read_verilog -specify -lib -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+hierarchy -check -auto-top
+# Start flow after library reading
+synth_xilinx -flatten -abc9 -nosrl -nodsp -iopad -run prepare:check
+
+# Read the design's timing constraints
+read_sdc $::env(DESIGN_TOP).input.sdc
+
+# Propagate the clocks
+propagate_clocks
+
+# Write the clocks to file
+set fh [open [test_output_path $::env(DESIGN_TOP).txt] w]
+puts $fh [get_clocks]
+puts $fh [get_clocks -include_generated_clocks]
+close $fh
+
+# Clean processes before writing JSON.
+yosys proc
+
+# Write out the SDC file after the clock propagation step
+write_sdc [test_output_path $::env(DESIGN_TOP).sdc]
+write_json [test_output_path $::env(DESIGN_TOP).json]

--- a/sdc-plugin/tests/create_clock_add/create_clock_add.v
+++ b/sdc-plugin/tests/create_clock_add/create_clock_add.v
@@ -1,0 +1,66 @@
+// Copyright (C) 2020-2021  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
+module top (
+    input clk,
+    input clk2,
+    input [1:0] in,
+    output [5:0] out
+);
+
+  reg [1:0] cnt = 0;
+  wire clk_int_1, clk_int_2;
+  IBUF ibuf_proxy (
+      .I(clk),
+      .O(ibuf_proxy_out)
+  );
+  IBUF ibuf_inst (
+      .I(ibuf_proxy_out),
+      .O(ibuf_out)
+  );
+  assign clk_int_1 = ibuf_out;
+  assign clk_int_2 = clk_int_1;
+
+  always @(posedge clk_int_2) begin
+    cnt <= cnt + 1;
+  end
+
+  middle middle_inst_1 (
+      .clk(ibuf_out),
+      .out(out[2])
+  );
+  middle middle_inst_2 (
+      .clk(clk_int_1),
+      .out(out[3])
+  );
+  middle middle_inst_3 (
+      .clk(clk_int_2),
+      .out(out[4])
+  );
+  middle middle_inst_4 (
+      .clk(clk2),
+      .out(out[5])
+  );
+
+  assign out[1:0] = {cnt[0], in[0]};
+endmodule
+
+module middle (
+    input  clk,
+    output out
+);
+
+  reg [1:0] cnt = 0;
+  wire clk_int;
+  assign clk_int = clk;
+  always @(posedge clk_int) begin
+    cnt <= cnt + 1;
+  end
+
+  assign out = cnt[0];
+endmodule


### PR DESCRIPTION
This PR fixes the problem reported in #177 without having to remove the `-add` option from the `create_clock` command.