### PR TITLE
Fix wrong struct value when it is used as module parameter

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1323,6 +1323,8 @@ void UhdmAst::simplify_parameter(AST::AstNode *parameter, AST::AstNode *module_n
     visitEachDescendant(shared.current_top_node, [&](AST::AstNode *current_scope_node) {
         if (current_scope_node->type == AST::AST_TYPEDEF || current_scope_node->type == AST::AST_PARAMETER ||
             current_scope_node->type == AST::AST_LOCALPARAM) {
+            if (current_scope_node->type == AST::AST_TYPEDEF)
+                simplify(current_scope_node, nullptr);
             AST_INTERNAL::current_scope[current_scope_node->str] = current_scope_node;
         }
     });
@@ -1330,6 +1332,8 @@ void UhdmAst::simplify_parameter(AST::AstNode *parameter, AST::AstNode *module_n
         visitEachDescendant(module_node, [&](AST::AstNode *current_scope_node) {
             if (current_scope_node->type == AST::AST_TYPEDEF || current_scope_node->type == AST::AST_PARAMETER ||
                 current_scope_node->type == AST::AST_LOCALPARAM) {
+                if (current_scope_node->type == AST::AST_TYPEDEF)
+                    simplify(current_scope_node, nullptr);
                 AST_INTERNAL::current_scope[current_scope_node->str] = current_scope_node;
             }
         });


### PR DESCRIPTION
This fixes sometimes wrong struct values for parameters that are used as module parameter.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>