### PR TITLE
qlf_k6n10f DSP multiplier inference

### DIFF
--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -23,17 +23,17 @@ ifeq (,$(wildcard $(YOSYS_CONFIG)))
 $(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
 endif
 
-GTEST_DIR ?= ../../third_party/googletest
+GTEST_DIR ?= $(abspath ../../third_party/googletest)
 CXX ?= $(shell $(YOSYS_CONFIG) --cxx)
 CXXFLAGS ?= $(shell $(YOSYS_CONFIG) --cxxflags) -I.. -I$(GTEST_DIR)/googletest/include
 LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
 LDFLAGS ?= $(shell $(YOSYS_CONFIG) --ldflags)
-TEST_UTILS ?= ../../../test-utils/test-utils.tcl
+TEST_UTILS ?= $(abspath ../../test-utils/test-utils.tcl)
 
 define test_tpl =
 $(1): $(1)/ok
 	@set +e; \
-	$$($(1)_verify); \
+	$$($$(subst /,-,$(1)_verify)); \
 	if [ $$$$? -eq 0 ]; then \
 		printf "Test %-18s \e[32mPASSED\e[0m @ %s\n" $(1) $(CURDIR); \
 		touch $$<; \
@@ -43,15 +43,15 @@ $(1): $(1)/ok
 		false; \
 	fi
 
-$(1)/ok: $(1)/$(1).v
+$(1)/ok: $(1)/$$(notdir $(1).v)
 	@set +e; \
 	cd $(1); \
-	echo "source $(TEST_UTILS)" > run-$(1).tcl ;\
-	echo "source $(1).tcl" >> run-$(1).tcl ;\
-	DESIGN_TOP=$(1) TEST_OUTPUT_PREFIX=./ \
-	yosys -c "run-$(1).tcl" -q -q -l $(1).log; \
+	echo "source $(TEST_UTILS)" > run-$$(notdir $(1)).tcl ;\
+	echo "source $$(notdir $(1)).tcl" >> run-$$(notdir $(1)).tcl ;\
+	DESIGN_TOP=$$(notdir $(1)) TEST_OUTPUT_PREFIX=./ \
+	yosys -c "run-$$(notdir $(1)).tcl" -q -q -l $$(notdir $(1)).log; \
 	RETVAL=$$$$?; \
-	rm -f run-$(1).tcl; \
+	rm -f run-$$(notdir $(1)).tcl; \
 	if [ ! -z "$$($(1)_negative)" ] && [ $$($(1)_negative) -eq 1 ]; then \
 		if [ $$$$RETVAL -ne 0 ]; then \
 			printf "Negative test %-18s \e[32mPASSED\e[0m @ %s\n" $(1) $(CURDIR); \

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -664,22 +664,61 @@ module TDP_BRAM36 (
 
 endmodule
 
-(* blackbox *)
-module QL_DSP1 (
-    input  [19:0] a,
-    input  [17:0] b,
-    input  clk0,
-    (* clkbuf_sink *)
-    input  clk1,
-    (* clkbuf_sink *)
-    input  [ 1:0] feedback0,
-    input  [ 1:0] feedback1,
-    input  load_acc0,
-    input  load_acc1,
-    input  reset0,
-    input  reset1,
-    output reg [37:0] z
-);
-    parameter MODE_BITS = 27'b00000000000000000000000000;
-endmodule  /* QL_DSP1 */
+//(* blackbox *)
+//module QL_DSP1 (
+//    input  [19:0] a,
+//    input  [17:0] b,
+//    input  clk0,
+//    (* clkbuf_sink *)
+//    input  clk1,
+//    (* clkbuf_sink *)
+//    input  [ 1:0] feedback0,
+//    input  [ 1:0] feedback1,
+//    input  load_acc0,
+//    input  load_acc1,
+//    input  reset0,
+//    input  reset1,
+//    output reg [37:0] z
+//);
+//    parameter MODE_BITS = 27'b00000000000000000000000000;
+//endmodule  /* QL_DSP1 */
 
+(* blackbox *) // TODO: add sim model
+module dsp_t1_20x18x64 (
+    input  [63:0] a_i,
+    input  [17:0] b_i,
+    output [63:0] z_o,
+
+    input         clock_i,
+    input         reset_i,
+    input         load_acc_i,
+
+    input         register_inputs_i,
+    input         subtraction_mode_i,
+    input  [1:0]  feedback_i,
+    input         round_i,
+    input  [5:0]  shift_right_i,
+    input         saturate_enable_i,
+    input  [1:0]  output_select_i
+);
+endmodule
+
+(* blackbox *) // TODO: add sim model
+module dsp_t1_10x9x32 (
+    input  [31:0] a_i,
+    input  [ 8:0] b_i,
+    output [31:0] z_o,
+
+    input         clock_i,
+    input         reset_i,
+    input         load_acc_i,
+
+    input         register_inputs_i,
+    input         subtraction_mode_i,
+    input  [1:0]  feedback_i,
+    input         round_i,
+    input  [5:0]  shift_right_i,
+    input         saturate_enable_i,
+    input  [1:0]  output_select_i
+);
+endmodule

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
@@ -6,22 +6,77 @@
 //
 // SPDX-License-Identifier:ISC
 
-module \$__MUL16X16 (input [15:0] A, input [15:0] B, output [31:0] Y);
-	parameter A_SIGNED = 0;
-	parameter B_SIGNED = 0;
-	parameter A_WIDTH = 0;
-	parameter B_WIDTH = 0;
-	parameter Y_WIDTH = 0;
+module \$__QL_MUL20X18 (input [19:0] A, input [17:0] B, output [37:0] Y);
+    parameter A_SIGNED = 0;
+    parameter B_SIGNED = 0;
+    parameter A_WIDTH = 0;
+    parameter B_WIDTH = 0;
+    parameter Y_WIDTH = 0;
 
-	QL_DSP #(
-		.A_REG(1'b0),
-		.B_REG(1'b0),
-		.C_REG(1'b0),
-		.D_REG(1'b0),
-		.ENABLE_DSP(1'b1),
-	) _TECHMAP_REPLACE_ (
-		.A(A),
-		.B(B),
-		.O(Y),
-	);
+    wire [19:0] a;
+    wire [17:0] b;
+    wire [63:0] z;
+
+    assign a = (A_WIDTH == 20) ? A :
+               (A_SIGNED) ? {{(20 - A_WIDTH){A[A_WIDTH-1]}}, A} :
+                            {{(20 - A_WIDTH){1'b0}},         A};
+
+    assign b = (B_WIDTH == 18) ? B :
+               (B_SIGNED) ? {{(18 - B_WIDTH){B[B_WIDTH-1]}}, B} :
+                            {{(18 - B_WIDTH){1'b0}},         B};
+
+    dsp_t1_20x18x64 _TECHMAP_REPLACE_ (
+        .a_i    (a),
+        .b_i    (b),
+        .z_o    (z),
+
+        .register_inputs_i  (1'b0),
+        .subtraction_mode_i (1'b0),
+        .feedback_i         (2'b00),
+        .round_i            (1'b0),
+        .shift_right_i      (1'b0),
+        .saturate_enable_i  (1'b0),
+        .output_select_i    (1'b0)
+    );
+
+    assign Y = z[37:0];
+
 endmodule
+
+module \$__QL_MUL20X18 (input [9:0] A, input [8:0] B, output [18:0] Y);
+    parameter A_SIGNED = 0;
+    parameter B_SIGNED = 0;
+    parameter A_WIDTH = 0;
+    parameter B_WIDTH = 0;
+    parameter Y_WIDTH = 0;
+
+    wire [ 9:0] a;
+    wire [ 8:0] b;
+    wire [31:0] z;
+
+    assign a = (A_WIDTH == 10) ? A :
+               (A_SIGNED) ? {{(10 - A_WIDTH){A[A_WIDTH-1]}}, A} :
+                            {{(10 - A_WIDTH){1'b0}},         A};
+
+    assign b = (B_WIDTH ==  9) ? B :
+               (B_SIGNED) ? {{( 9 - B_WIDTH){B[B_WIDTH-1]}}, B} :
+                            {{( 9 - B_WIDTH){1'b0}},         B};
+
+    dsp_t1_10x9x32 _TECHMAP_REPLACE_ (
+        .a_i    (a),
+        .b_i    (b),
+        .z_o    (z),
+
+        .register_inputs_i  (1'b0),
+        .subtraction_mode_i (1'b0),
+        .feedback_i         (2'b00),
+        .round_i            (1'b0),
+        .shift_right_i      (1'b0),
+        .saturate_enable_i  (1'b0),
+        .output_select_i    (1'b0)
+    );
+
+    assign Y = z[18:0];
+
+endmodule
+

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
@@ -43,7 +43,7 @@ module \$__QL_MUL20X18 (input [19:0] A, input [17:0] B, output [37:0] Y);
 
 endmodule
 
-module \$__QL_MUL20X18 (input [9:0] A, input [8:0] B, output [18:0] Y);
+module \$__QL_MUL10X9 (input [9:0] A, input [8:0] B, output [18:0] Y);
     parameter A_SIGNED = 0;
     parameter B_SIGNED = 0;
     parameter A_WIDTH = 0;

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -262,7 +262,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                 };
 
                 const std::vector<DspParams> dsp_rules = {
-                    {20, 18,  4,  4, "$__QL_MUL20X18"},
+                    {20, 18, 11, 10, "$__QL_MUL20X18"},
                     {10,  9,  4,  4, "$__QL_MUL10X9"},
                 };
 

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -20,7 +20,8 @@ TESTS = consts \
 	mux \
 	tribuf \
 	fsm \
-	pp3_bram #\
+	pp3_bram \
+    qlf_k6n10f/dsp_mult
 #	qlf_k6n10_bram \
 
 include $(shell pwd)/../../Makefile_test.common
@@ -38,4 +39,5 @@ mux_verify = true
 tribuf_verify = true
 fsm_verify = true
 pp3_bram_verify = true
+qlf_k6n10f-dsp_mult_verify = true
 #qlf_k6n10_bram_verify = true

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.tcl
@@ -1,0 +1,35 @@
+yosys -import
+if { [info procs quicklogic_eqn] == {} } { plugin -i ql-qlf}
+yosys -import  ;# ingest plugin commands
+
+read_verilog dsp_mult.v
+design -save read
+
+set TOP "mult_16x16"
+design -load read
+hierarchy -top $TOP
+synth_quicklogic -family qlf_k6n10f -top $TOP
+yosys cd $TOP
+select -assert-count 1 t:dsp_t1_20x18x64
+
+set TOP "mult_20x18"
+design -load read
+hierarchy -top $TOP
+synth_quicklogic -family qlf_k6n10f -top $TOP
+yosys cd $TOP
+select -assert-count 1 t:dsp_t1_20x18x64
+
+set TOP "mult_8x8"
+design -load read
+hierarchy -top $TOP
+synth_quicklogic -family qlf_k6n10f -top $TOP
+yosys cd $TOP
+select -assert-count 1 t:dsp_t1_10x9x32
+
+set TOP "mult_10x9"
+design -load read
+hierarchy -top $TOP
+synth_quicklogic -family qlf_k6n10f -top $TOP
+yosys cd $TOP
+select -assert-count 1 t:dsp_t1_10x9x32
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.v
@@ -1,0 +1,39 @@
+module mult_16x16 (
+    input  wire [15:0] A,
+    input  wire [15:0] B,
+    output wire [31:0] Z
+);
+
+    assign Z = A * B;
+
+endmodule
+
+module mult_20x18 (
+    input  wire [19:0] A,
+    input  wire [17:0] B,
+    output wire [37:0] Z
+);
+
+    assign Z = A * B;
+
+endmodule
+
+module mult_8x8 (
+    input  wire [ 7:0] A,
+    input  wire [ 7:0] B,
+    output wire [15:0] Z
+);
+
+    assign Z = A * B;
+
+endmodule
+
+module mult_10x9 (
+    input  wire [ 9:0] A,
+    input  wire [ 8:0] B,
+    output wire [18:0] Z
+);
+
+    assign Z = A * B;
+
+endmodule


### PR DESCRIPTION
This PR adds preliminary support for inference of DSP-based multipliers for `qlf_k6n10f`.

There are two new blackbox models `dsp_t1_20x18x64` and `dsp_t1_10x9x32` representing the whole DSP and one half of it. Simulation models for them will be added in subsequent PRs. Also their definitions (ports/parameters) may change.

The `synth_quicklogic` pass for  `qlf_k6n10f` now has the ability to infer multipliers. This is done by the generic `mul2dsp.v` techmap from Yosys. Techmapping is done in multiple stages where each subsequent stage maps to "smaller" DSPs. The techmap transforms internal `$mul` cells into `__QL_MUL20X18` or `__QL_MUL10X9` which are then techmapped to the final DSP cells present in the architecture by `qlf_k6n10f/dsp_map.v`.

There is a test added which verifies if the inference takes place but since there are no simulation models yet there is no equivalence checking / simulation.
